### PR TITLE
Add typestate to builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "typenum",
  "uuid",
 ]
 
@@ -375,6 +376,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "typenum",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "to_composite_id_macro",
  "typenum",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,14 @@ name = "base_types"
 version = "0.1.0"
 dependencies = [
  "leptos",
+ "molecule_core",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
+ "to_composite_id_macro",
  "typenum",
  "uuid",
 ]
@@ -760,6 +762,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "molecule_core"
+version = "0.1.0"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "molecule_schema"
 version = "0.1.0"
 dependencies = [
@@ -1350,6 +1359,17 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "to_composite_id_macro"
+version = "0.1.0"
+dependencies = [
+ "molecule_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "typenum",
+]
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,12 @@
 [workspace]
 resolver = "2"
 members = [
-  "molecule_schema",
-  "generate_schema_reactive",
-  "base_types",
-  "reactive_types",
+    "molecule_schema",
+    "generate_schema_reactive",
+    "base_types",
+    "reactive_types",
+    "to_composite_id_macro",
+    "molecule_core",
 ]
 
 

--- a/base_types/Cargo.toml
+++ b/base_types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 serde = ["serde/derive", "serde/rc", "serde_json"]
 to_tokens = ["proc-macro2", "quote"]
-reactive = ["leptos"]
+# reactive = ["leptos"]
 
 [dependencies.uuid]
 version = "1.4.1"
@@ -27,5 +27,5 @@ strum_macros = "0.26.1"
 # anyhow = "1.0"
 quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
-leptos = { version = "0.6", features = ["csr"], optional = true }
+leptos = { version = "0.6", features = ["csr"] }
 typenum = "1"

--- a/base_types/Cargo.toml
+++ b/base_types/Cargo.toml
@@ -29,3 +29,5 @@ quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 leptos = { version = "0.6", features = ["csr"] }
 typenum = "1"
+to_composite_id_macro = { path = "../to_composite_id_macro" }
+molecule_core = { path = "../molecule_core" }

--- a/base_types/Cargo.toml
+++ b/base_types/Cargo.toml
@@ -28,3 +28,4 @@ strum_macros = "0.26.1"
 quote = { version = "1.0", optional = true }
 proc-macro2 = { version = "1.0", optional = true }
 leptos = { version = "0.6", features = ["csr"], optional = true }
+typenum = "1"

--- a/base_types/src/constraint_schema.rs
+++ b/base_types/src/constraint_schema.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use std::{collections::HashMap, marker::PhantomData};
+use std::{collections::BTreeMap, marker::PhantomData};
 
 pub type SlotId = Uid;
 pub type TraitId = Uid;
@@ -9,19 +9,19 @@ pub type FieldId = Uid;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Default)]
 pub struct ConstraintSchema<TTypes: ConstraintTraits, TValues: ConstraintTraits> {
-    pub template_library: HashMap<Uid, LibraryTemplate<TTypes, TValues>>,
-    pub instance_library: HashMap<Uid, LibraryOperative<TTypes, TValues>>,
-    pub operative_library: HashMap<Uid, LibraryOperative<TTypes, TValues>>,
-    pub traits: HashMap<Uid, TraitDef<TTypes>>,
+    pub template_library: BTreeMap<Uid, LibraryTemplate<TTypes, TValues>>,
+    pub instance_library: BTreeMap<Uid, LibraryOperative<TTypes, TValues>>,
+    pub operative_library: BTreeMap<Uid, LibraryOperative<TTypes, TValues>>,
+    pub traits: BTreeMap<Uid, TraitDef<TTypes>>,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct LibraryTemplate<TTypes: ConstraintTraits, TValues: ConstraintTraits> {
     pub tag: Tag,
-    pub field_constraints: HashMap<FieldId, FieldConstraint<TTypes>>,
-    pub operative_slots: HashMap<SlotId, OperativeSlot>,
-    pub trait_impls: HashMap<TraitId, TraitImpl>,
+    pub field_constraints: BTreeMap<FieldId, FieldConstraint<TTypes>>,
+    pub operative_slots: BTreeMap<SlotId, OperativeSlot>,
+    pub trait_impls: BTreeMap<TraitId, TraitImpl>,
     pub instances: Vec<Uid>,
     #[cfg_attr(feature = "serde", serde(skip))]
     pub _phantom: PhantomData<TValues>,
@@ -34,9 +34,9 @@ pub struct LibraryOperative<TTypes: ConstraintTraits, TValues: ConstraintTraits>
     pub template_id: Uid,
     // If the operative is based on another operative
     pub parent_operative_id: Option<Uid>,
-    pub slotted_instances: HashMap<SlotId, SlottedInstances>,
-    pub locked_fields: HashMap<FieldId, LockedFieldConstraint<TValues>>,
-    pub trait_impls: HashMap<TraitId, TraitImpl>,
+    pub slotted_instances: BTreeMap<SlotId, SlottedInstances>,
+    pub locked_fields: BTreeMap<FieldId, LockedFieldConstraint<TValues>>,
+    pub trait_impls: BTreeMap<TraitId, TraitImpl>,
     pub _phantom: PhantomData<TTypes>,
 }
 
@@ -77,7 +77,7 @@ pub struct TraitOperative {
 #[derive(Clone, Debug)]
 pub struct TraitDef<TTypes: ConstraintTraits> {
     pub tag: Tag,
-    pub methods: HashMap<Uid, TraitMethodDef<TTypes>>,
+    pub methods: BTreeMap<Uid, TraitMethodDef<TTypes>>,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -110,7 +110,7 @@ pub struct SlottedInstances {
     pub fulfilling_instance_ids: Vec<Uid>,
 }
 
-pub type TraitImpl = HashMap<TraitMethodId, Vec<TraitMethodImplPath>>;
+pub type TraitImpl = BTreeMap<TraitMethodId, Vec<TraitMethodImplPath>>;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]

--- a/base_types/src/constraint_schema_item.rs
+++ b/base_types/src/constraint_schema_item.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+};
 
 use crate::{
     common::{ConstraintTraits, Tag, Uid},
@@ -17,8 +20,8 @@ pub trait ConstraintSchemaItem {
     fn get_template_id(&self) -> &Uid;
     fn get_parent_operative_id(&self) -> Option<&Uid>;
     fn get_tag(&self) -> &Tag;
-    fn get_local_trait_impls(&self) -> &HashMap<TraitId, TraitImpl>;
-    fn get_local_slotted_instances(&self) -> Option<&HashMap<Uid, SlottedInstances>>;
+    fn get_local_trait_impls(&self) -> &BTreeMap<TraitId, TraitImpl>;
+    fn get_local_slotted_instances(&self) -> Option<&BTreeMap<Uid, SlottedInstances>>;
     fn check_ancestry(
         &self,
         schema: &ConstraintSchema<Self::TTypes, Self::TValues>,
@@ -51,7 +54,7 @@ pub trait ConstraintSchemaItem {
     }
     fn get_local_locked_fields(
         &self,
-    ) -> Option<&HashMap<FieldId, LockedFieldConstraint<Self::TValues>>>;
+    ) -> Option<&BTreeMap<FieldId, LockedFieldConstraint<Self::TValues>>>;
     fn get_trait_impl_digest<'a>(
         &'a self,
         schema: &'a ConstraintSchema<Self::TTypes, Self::TValues>,
@@ -80,15 +83,15 @@ impl<TTypes: ConstraintTraits, TValues: ConstraintTraits> ConstraintSchemaItem
     fn get_tag(&self) -> &Tag {
         &self.tag
     }
-    fn get_local_trait_impls(&self) -> &HashMap<TraitId, TraitImpl> {
+    fn get_local_trait_impls(&self) -> &BTreeMap<TraitId, TraitImpl> {
         &self.trait_impls
     }
-    fn get_local_slotted_instances(&self) -> Option<&HashMap<Uid, SlottedInstances>> {
+    fn get_local_slotted_instances(&self) -> Option<&BTreeMap<Uid, SlottedInstances>> {
         None
     }
     fn get_local_locked_fields(
         &self,
-    ) -> Option<&HashMap<Uid, LockedFieldConstraint<Self::TValues>>> {
+    ) -> Option<&BTreeMap<Uid, LockedFieldConstraint<Self::TValues>>> {
         None
     }
     fn get_operative_digest(&self, _schema: &ConstraintSchema<TTypes, TValues>) -> OperativeDigest {
@@ -153,15 +156,15 @@ impl<TTypes: ConstraintTraits, TValues: ConstraintTraits> ConstraintSchemaItem
     fn get_tag(&self) -> &Tag {
         &self.tag
     }
-    fn get_local_trait_impls(&self) -> &HashMap<TraitId, TraitImpl> {
+    fn get_local_trait_impls(&self) -> &BTreeMap<TraitId, TraitImpl> {
         &self.trait_impls
     }
-    fn get_local_slotted_instances(&self) -> Option<&HashMap<Uid, SlottedInstances>> {
+    fn get_local_slotted_instances(&self) -> Option<&BTreeMap<Uid, SlottedInstances>> {
         Some(&self.slotted_instances)
     }
     fn get_local_locked_fields(
         &self,
-    ) -> Option<&HashMap<Uid, LockedFieldConstraint<Self::TValues>>> {
+    ) -> Option<&BTreeMap<Uid, LockedFieldConstraint<Self::TValues>>> {
         Some(&self.locked_fields)
     }
     fn get_operative_digest<'a>(

--- a/base_types/src/lib.rs
+++ b/base_types/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "4096"]
+#![recursion_limit = "2048"]
 pub mod common;
 pub mod constraint_schema;
 pub mod constraint_schema_item;

--- a/base_types/src/lib.rs
+++ b/base_types/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "4096"]
 pub mod common;
 pub mod constraint_schema;
 pub mod constraint_schema_item;

--- a/base_types/src/lib.rs
+++ b/base_types/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "2048"]
+#![recursion_limit = "4096"]
 pub mod common;
 pub mod constraint_schema;
 pub mod constraint_schema_item;

--- a/base_types/src/lib.rs
+++ b/base_types/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "4096"]
+pub use to_composite_id_macro;
 pub mod common;
 pub mod constraint_schema;
 pub mod constraint_schema_item;

--- a/base_types/src/locked_field_digest.rs
+++ b/base_types/src/locked_field_digest.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+};
 
 use crate::{
     common::{ConstraintTraits, Uid},
@@ -9,7 +12,7 @@ use crate::{
 pub struct LockedFieldsDigest<'a, TTypes: ConstraintTraits, TValues: ConstraintTraits> {
     pub digest_object_id: Uid,
     pub locked_fields: HashMap<Uid, LockedFieldDigest<TValues>>,
-    pub field_constraints: Cow<'a, HashMap<Uid, FieldConstraint<TTypes>>>,
+    pub field_constraints: Cow<'a, BTreeMap<Uid, FieldConstraint<TTypes>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -25,7 +28,7 @@ impl<'a, TTypes: ConstraintTraits, TValues: ConstraintTraits>
     pub fn new(object_id: Uid) -> Self {
         Self {
             locked_fields: HashMap::new(),
-            field_constraints: Cow::Owned(HashMap::new()),
+            field_constraints: Cow::Owned(BTreeMap::new()),
             digest_object_id: object_id,
         }
     }

--- a/base_types/src/operative_digest.rs
+++ b/base_types/src/operative_digest.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
+/// Represents a snapshot of the state of the slots for a given operative
 pub struct OperativeDigest<'a> {
     pub digest_object_id: Uid,
     pub operative_slots: HashMap<Uid, OperativeSlotDigest<'a>>,

--- a/base_types/src/operative_digest.rs
+++ b/base_types/src/operative_digest.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{
     common::{ConstraintTraits, Uid},
@@ -9,7 +9,7 @@ use crate::{
 /// Represents a snapshot of the state of the slots for a given operative
 pub struct OperativeDigest<'a> {
     pub digest_object_id: Uid,
-    pub operative_slots: HashMap<Uid, OperativeSlotDigest<'a>>,
+    pub operative_slots: BTreeMap<Uid, OperativeSlotDigest<'a>>,
 }
 
 #[derive(Clone, Debug)]

--- a/base_types/src/post_generation/mod.rs
+++ b/base_types/src/post_generation/mod.rs
@@ -2,5 +2,6 @@ pub mod non_reactive;
 #[cfg(feature = "reactive")]
 pub mod reactive;
 mod tests;
+pub mod type_level;
 
 pub use non_reactive::*;

--- a/base_types/src/post_generation/mod.rs
+++ b/base_types/src/post_generation/mod.rs
@@ -1,7 +1,9 @@
 pub mod non_reactive;
-#[cfg(feature = "reactive")]
-pub mod reactive;
 mod tests;
+
+// #[cfg(feature = "reactive")]
+pub mod reactive;
+// #[cfg(feature = "reactive")]
 pub mod type_level;
 
 pub use non_reactive::*;

--- a/base_types/src/post_generation/non_reactive.rs
+++ b/base_types/src/post_generation/non_reactive.rs
@@ -112,10 +112,6 @@ pub struct FieldEdit {
     pub value: PrimitiveValues,
 }
 
-pub trait FieldEditable {
-    fn apply_field_edit(&mut self, field_edit: FieldEdit);
-}
-
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StrSlotRef {
@@ -208,7 +204,7 @@ pub struct HistoryContainer<TSchema> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 /// Normalizes GSOWrapper for network transfer
-pub struct StandaloneRGSOWrapper {
+pub struct StandaloneRGSOConcrete {
     pub id: Uid,
     pub fields: std::collections::HashMap<Uid, PrimitiveValues>,
     pub outgoing_slots: Vec<SlotRef>,

--- a/base_types/src/post_generation/non_reactive.rs
+++ b/base_types/src/post_generation/non_reactive.rs
@@ -12,6 +12,22 @@ use crate::{
     primitives::{PrimitiveTypes, PrimitiveValues},
 };
 
+// Used for MainBuilder Typestate
+// ---
+pub trait AllSlotsSatisfied {}
+pub trait AllFieldsSatisfied {}
+pub trait ReadyForBuild<T>: AllSlotsSatisfied + AllFieldsSatisfied {
+    fn build(&self) -> T;
+}
+
+pub struct Yes {}
+pub struct No {}
+pub struct SlotTypeState<AddAllowed, RemoveAllowed, Fulfilled>(
+    PhantomData<(AddAllowed, RemoveAllowed, Fulfilled)>,
+);
+
+// ---
+
 pub type LibOp = LibraryOperative<PrimitiveTypes, PrimitiveValues>;
 pub type LibTemplate = LibraryTemplate<PrimitiveTypes, PrimitiveValues>;
 

--- a/base_types/src/post_generation/non_reactive.rs
+++ b/base_types/src/post_generation/non_reactive.rs
@@ -12,22 +12,6 @@ use crate::{
     primitives::{PrimitiveTypes, PrimitiveValues},
 };
 
-// Used for MainBuilder Typestate
-// ---
-pub trait AllSlotsSatisfied {}
-pub trait AllFieldsSatisfied {}
-pub trait ReadyForBuild<T>: AllSlotsSatisfied + AllFieldsSatisfied {
-    fn build(&self) -> T;
-}
-
-pub struct Yes {}
-pub struct No {}
-pub struct SlotTypeState<AddAllowed, RemoveAllowed, Fulfilled>(
-    PhantomData<(AddAllowed, RemoveAllowed, Fulfilled)>,
-);
-
-// ---
-
 pub type LibOp = LibraryOperative<PrimitiveTypes, PrimitiveValues>;
 pub type LibTemplate = LibraryTemplate<PrimitiveTypes, PrimitiveValues>;
 

--- a/base_types/src/post_generation/non_reactive.rs
+++ b/base_types/src/post_generation/non_reactive.rs
@@ -65,10 +65,10 @@ pub trait GraphEnvironment {
     fn create_connection(&mut self, connection: ConnectionAction) -> Result<(), Error>;
     fn instantiate_element<T>(
         &mut self,
-        element: InstantiableWrapper<GSOWrapper<T>, Self::Schema>,
+        element: InstantiableWrapper<GSOConcrete<T>, Self::Schema>,
     ) -> Result<Uid, Error>
     where
-        GSOWrapper<T>: Instantiable<Schema = Self::Schema>,
+        GSOConcrete<T>: Instantiable<Schema = Self::Schema>,
         Self: Sized,
         T: std::fmt::Debug + Clone + 'static;
     fn get_mut(&mut self, id: &Uid) -> Option<&mut Self::Schema>;
@@ -214,7 +214,7 @@ pub struct StandaloneRGSOConcrete {
 }
 #[derive(Clone)]
 /// Struct which abstracts all common parts of a generated schema object
-pub struct GSOWrapper<T> {
+pub struct GSOConcrete<T> {
     pub id: Uid,
     pub outgoing_slots: HashMap<Uid, ActiveSlot>,
     pub incoming_slots: Vec<SlotRef>,
@@ -223,7 +223,7 @@ pub struct GSOWrapper<T> {
     pub template: &'static LibraryTemplate<PrimitiveTypes, PrimitiveValues>,
     pub _phantom: PhantomData<T>,
 }
-impl<T: std::fmt::Debug> std::fmt::Debug for GSOWrapper<T> {
+impl<T: std::fmt::Debug> std::fmt::Debug for GSOConcrete<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GSOWrapper")
             .field("id", &self.id)
@@ -250,7 +250,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for GSOWrapper<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct GSOWrapperBuilder<T> {
+pub struct GSOConcreteBuilder<T> {
     id: Uid,
     slots: HashMap<Uid, ActiveSlot>,
     parent_slots: Vec<SlotRef>,
@@ -260,7 +260,7 @@ pub struct GSOWrapperBuilder<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<T: Clone + std::fmt::Debug> GSOWrapperBuilder<T> {
+impl<T: Clone + std::fmt::Debug> GSOConcreteBuilder<T> {
     pub fn new(
         data: Option<HashMap<Uid, Option<PrimitiveValues>>>,
         slots: Option<HashMap<Uid, ActiveSlot>>,
@@ -298,12 +298,12 @@ impl<T: Clone + std::fmt::Debug> GSOWrapperBuilder<T> {
 pub trait Buildable
 where
     Self: Sized + 'static,
-    GSOWrapper<Self>: Instantiable<Schema = Self::Schema>,
+    GSOConcrete<Self>: Instantiable<Schema = Self::Schema>,
 {
-    type Builder: Finalizable<GSOWrapper<Self>>;
+    type Builder: Finalizable<GSOConcrete<Self>>;
     type Schema;
 
-    fn initiate_build() -> GSOBuilder<Self::Builder, GSOWrapper<Self>, Self::Schema>;
+    fn initiate_build() -> GSOBuilder<Self::Builder, GSOConcrete<Self>, Self::Schema>;
     fn get_operative_id() -> Uid;
 }
 
@@ -362,5 +362,5 @@ where
     Self: Sized,
 {
     type Schema;
-    fn into_schema(instantiable: GSOWrapper<Self>) -> Self::Schema;
+    fn into_schema(instantiable: GSOConcrete<Self>) -> Self::Schema;
 }

--- a/base_types/src/post_generation/reactive.rs
+++ b/base_types/src/post_generation/reactive.rs
@@ -23,7 +23,7 @@ where
     fn from_non_reactive(value: NTSchema, graph: std::rc::Rc<RBaseGraphEnvironment<Self>>) -> Self;
 }
 pub fn saturate_wrapper<T: Clone + std::fmt::Debug, RTSchema: EditRGSO<Schema = RTSchema>>(
-    non_reactive: crate::post_generation::GSOWrapper<T>,
+    non_reactive: crate::post_generation::GSOConcrete<T>,
     graph: std::rc::Rc<RBaseGraphEnvironment<RTSchema>>,
 ) -> RGSOConcrete<T, RTSchema> {
     RGSOConcrete::<T, RTSchema> {
@@ -1352,7 +1352,7 @@ mod from_reactive {
     use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
     use super::SharedGraph;
-    use crate::post_generation::{BaseGraphEnvironment, GSOWrapper};
+    use crate::post_generation::{BaseGraphEnvironment, GSOConcrete};
     use leptos::*;
 
     use super::{
@@ -1421,7 +1421,7 @@ mod from_reactive {
             }
         }
     }
-    impl<T, RTSchema: EditRGSO<Schema = RTSchema>> From<RGSOConcrete<T, RTSchema>> for GSOWrapper<T>
+    impl<T, RTSchema: EditRGSO<Schema = RTSchema>> From<RGSOConcrete<T, RTSchema>> for GSOConcrete<T>
     where
         T: Clone + std::fmt::Debug,
     {

--- a/base_types/src/post_generation/reactive.rs
+++ b/base_types/src/post_generation/reactive.rs
@@ -14,7 +14,7 @@ use crate::post_generation::{
 };
 use crate::utils::IntoPrimitiveValue;
 use leptos::{RwSignal, *};
-use std::collections::HashMap;
+use std::{collections::HashMap, marker::PhantomData};
 
 pub trait FromNonReactive<NTSchema>
 where

--- a/base_types/src/post_generation/reactive.rs
+++ b/base_types/src/post_generation/reactive.rs
@@ -1,7 +1,7 @@
 // pub mod from_reactive;
-
 pub use crate::common::Uid;
 use crate::constraint_schema::{LibraryOperative, LibraryTemplate, OperativeSlot, SlotBounds};
+pub use typenum;
 
 use crate::{
     common::ConstraintTraits,

--- a/base_types/src/post_generation/tests.rs
+++ b/base_types/src/post_generation/tests.rs
@@ -25,11 +25,6 @@
 // //     // type Graph = G;
 // // }
 
-// impl FieldEditable for SampleSchema {
-//     fn apply_field_edit(&mut self, field_edit: FieldEdit) {
-//         todo!()
-//     }
-// }
 // impl GSO for SampleSchema {
 //     type Schema = SampleSchema;
 
@@ -76,11 +71,6 @@
 
 // #[derive(Debug, Clone, Default)]
 // struct Sentence {}
-// impl FieldEditable for Sentence {
-//     fn apply_field_edit(&mut self, field_edit: FieldEdit) {
-//         todo!()
-//     }
-// }
 // impl IntoSchema for Sentence {
 //     type Schema = SampleSchema;
 
@@ -193,11 +183,6 @@
 // #[derive(Default, Debug, Clone)]
 // struct Word {
 //     display: String,
-// }
-// impl FieldEditable for Word {
-//     fn apply_field_edit(&mut self, field_edit: FieldEdit) {
-//         todo!()
-//     }
 // }
 // impl IntoSchema for Word {
 //     type Schema = SampleSchema;

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -1,12 +1,9 @@
+use molecule_core::CompId;
 use std::{
-    any::TypeId,
-    fmt::Debug,
     marker::PhantomData,
-    ops::{Add, BitAnd, BitOr, Not, Sub},
+    ops::{Add, BitAnd, BitOr},
 };
 use typenum::*;
-
-use super::reactive::{EditRGSO, RBaseGraphEnvironment};
 
 pub type NonExistent = P9;
 
@@ -18,7 +15,7 @@ pub trait SlotTSMarker {
     type CountIsLessThanMax: Bit;
 }
 pub struct SlotTS<
-    // Id,
+    Id,
     Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
     Min: Integer,
     MinIsNonExistent: Bit,
@@ -27,7 +24,7 @@ pub struct SlotTS<
     ZeroAllowed: Bit,
 >(
     PhantomData<(
-        // Id,
+        Id,
         Count,
         Min,
         MinIsNonExistent,
@@ -37,6 +34,7 @@ pub struct SlotTS<
     )>,
 );
 impl<
+        Id,
         Count: Integer
             + IsGreaterOrEqual<Min>
             + IsGreater<Min>
@@ -48,7 +46,8 @@ impl<
         Max: Integer,
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > SlotTSMarker for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+    > SlotTSMarker
+    for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
 {
     type CountIsGreaterThanOrEqualToMin = GrEq<Count, Min>;
     type CountIsGreaterThanMin = Gr<Count, Min>;
@@ -59,6 +58,7 @@ impl<
 
 pub trait CountIsLessThanOrEqualToMax {}
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
@@ -66,9 +66,9 @@ impl<
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
     > CountIsLessThanOrEqualToMax
-    for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+    for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
 where
-    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+    SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
         SlotTSMarker<CountIsLessThanOrEqualToMax = B1>,
 {
 }
@@ -76,31 +76,34 @@ where
 pub trait WithinUpperBounds {}
 // If Max does not exist
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
         Max: Integer,
         // MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > WithinUpperBounds for SlotTS<Count, Min, MinIsNonExistent, Max, B1, ZeroAllowed>
+    > WithinUpperBounds for SlotTS<Id, Count, Min, MinIsNonExistent, Max, B1, ZeroAllowed>
 {
 }
 // If Max does exist and count is less than it
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
         Max: Integer,
         // MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > WithinUpperBounds for SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>
+    > WithinUpperBounds for SlotTS<Id, Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>
 where
-    SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>: CountIsLessThanOrEqualToMax,
+    SlotTS<Id, Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>: CountIsLessThanOrEqualToMax,
 {
 }
 
 pub trait CountIsGreaterThanOrEqualToMin {}
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
@@ -108,9 +111,9 @@ impl<
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
     > CountIsGreaterThanOrEqualToMin
-    for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+    for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
 where
-    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+    SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
         SlotTSMarker<CountIsGreaterThanOrEqualToMin = B1>,
 {
 }
@@ -118,26 +121,28 @@ where
 pub trait WithinLowerBounds {}
 // If Min exists and Count is greater than it
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         // MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > WithinLowerBounds for SlotTS<Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>
+    > WithinLowerBounds for SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>
 where
-    SlotTS<Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>: CountIsGreaterThanOrEqualToMin,
+    SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>: CountIsGreaterThanOrEqualToMin,
 {
 }
 // If Min does not exist
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         // MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > WithinLowerBounds for SlotTS<Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>
+    > WithinLowerBounds for SlotTS<Id, Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>
 {
 }
 
@@ -145,15 +150,17 @@ pub trait FulfilledSlotTS {
     const IMPLEMENTED: bool = true;
 }
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > FulfilledSlotTS for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+    > FulfilledSlotTS
+    for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
 where
-    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+    SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
         WithinLowerBounds + WithinUpperBounds,
 {
 }
@@ -163,26 +170,28 @@ pub trait SlotCanAddOne {
 }
 // If Max does not exist
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
         Max: Integer,
         // MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > SlotCanAddOne for SlotTS<Count, Min, MinIsNonExistent, Max, B1, ZeroAllowed>
+    > SlotCanAddOne for SlotTS<Id, Count, Min, MinIsNonExistent, Max, B1, ZeroAllowed>
 {
 }
 // If Max does exist and count is less than it
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         MinIsNonExistent: Bit,
         Max: Integer,
         // MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > SlotCanAddOne for SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>
+    > SlotCanAddOne for SlotTS<Id, Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>
 where
-    SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>:
+    SlotTS<Id, Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>:
         SlotTSMarker<CountIsLessThanMax = B1>,
 {
 }
@@ -192,44 +201,608 @@ pub trait SlotCanSubtractOne {
 }
 // If Min does not exist
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         // MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         ZeroAllowed: Bit,
-    > SlotCanSubtractOne for SlotTS<Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>
+    > SlotCanSubtractOne for SlotTS<Id, Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>
 where
-    SlotTS<Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>:
+    SlotTS<Id, Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>:
         SlotTSMarker<CountIsGreaterThanZero = B1>,
 {
 }
 // If Min does exist and zero is not allowed
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         // MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         // ZeroAllowed: Bit,
-    > SlotCanSubtractOne for SlotTS<Count, Min, B0, Max, MaxIsNonExistent, B0>
+    > SlotCanSubtractOne for SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, B0>
 where
-    SlotTS<Count, Min, B0, Max, MaxIsNonExistent, B0>: SlotTSMarker<CountIsGreaterThanMin = B1>,
+    SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, B0>: SlotTSMarker<CountIsGreaterThanMin = B1>,
 {
 }
 // If Min does exist and zero is allowed
 impl<
+        Id,
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
         // MinIsNonExistent: Bit,
         Max: Integer,
         MaxIsNonExistent: Bit,
         // ZeroAllowed: Bit,
-    > SlotCanSubtractOne for SlotTS<Count, Min, B0, Max, MaxIsNonExistent, B1>
+    > SlotCanSubtractOne for SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, B1>
 where
-    SlotTS<Count, Min, B0, Max, MaxIsNonExistent, B1>: SlotTSMarker<CountIsGreaterThanZero = B1>,
+    SlotTS<Id, Count, Min, B0, Max, MaxIsNonExistent, B1>:
+        SlotTSMarker<CountIsGreaterThanZero = B1>,
 {
 }
+
+// ------------------------------------
+// Define a composite Id type
+// ------------------------------------
+
+pub trait IdIsEqual<Rhs = Self> {
+    type Output: Bit;
+}
+type IdEq<Lhs, Rhs> = <Lhs as IdIsEqual<Rhs>>::Output;
+
+impl<
+        A1: Unsigned,
+        B1: Unsigned,
+        C1: Unsigned,
+        D1: Unsigned,
+        A2: Unsigned,
+        B2: Unsigned,
+        C2: Unsigned,
+        D2: Unsigned,
+    > IdIsEqual<CompId<A2, B2, C2, D2>> for CompId<A1, B1, C1, D1>
+where
+    A1: IsEqual<A2>,
+    B1: IsEqual<B2>,
+    C1: IsEqual<C2>,
+    D1: IsEqual<D2>,
+    Eq<A1, A2>: BitAnd<Eq<B1, B2>>,
+    And<Eq<A1, A2>, Eq<B1, B2>>: Bit,
+    And<Eq<A1, A2>, Eq<B1, B2>>: BitAnd<Eq<C1, C2>>,
+    And<And<Eq<A1, A2>, Eq<B1, B2>>, Eq<C1, C2>>: Bit,
+    And<And<Eq<A1, A2>, Eq<B1, B2>>, Eq<C1, C2>>: BitAnd<Eq<D1, D2>>,
+    And<And<And<Eq<A1, A2>, Eq<B1, B2>>, Eq<C1, C2>>, Eq<D1, D2>>: Bit,
+{
+    type Output = And<And<And<Eq<A1, A2>, Eq<B1, B2>>, Eq<C1, C2>>, Eq<D1, D2>>;
+}
+// N1 is used to denote a not-found item, so it will never be equal to any CompositeId
+impl<A: Unsigned, B: Unsigned, C: Unsigned, D: Unsigned> IdIsEqual<CompId<A, B, C, D>> for N1 {
+    type Output = B0;
+}
+impl<A: Unsigned, B: Unsigned, C: Unsigned, D: Unsigned> IdIsEqual<N1> for CompId<A, B, C, D> {
+    type Output = B0;
+}
+impl IdIsEqual<N1> for N1 {
+    type Output = B1;
+}
+
+pub struct OperativeTS<Id, State>(PhantomData<(Id, State)>);
+
+pub trait IdGetter {
+    type Id;
+}
+impl<IdA: Unsigned, IdB: Unsigned, IdC: Unsigned, IdD: Unsigned, State> IdGetter
+    for OperativeTS<CompId<IdA, IdB, IdC, IdD>, State>
+{
+    type Id = CompId<IdA, IdB, IdC, IdD>;
+}
+impl<
+        Id,
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > IdGetter for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+{
+    type Id = Id;
+}
+impl IdGetter for () {
+    type Id = N1;
+}
+
+pub trait StateGetter {
+    type State;
+}
+impl<Id, State> StateGetter for OperativeTS<Id, State> {
+    type State = State;
+}
+impl<
+        Id,
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > StateGetter for SlotTS<Id, Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+{
+    type State = Count;
+}
+
+pub trait IfThenElse<Condition: Bit> {
+    type Output;
+}
+
+impl<T, F> IfThenElse<B1> for (T, F) {
+    type Output = T;
+}
+impl<T, F> IfThenElse<B0> for (T, F) {
+    type Output = F;
+}
+
+// --------------------------------------
+// FIND
+// --------------------------------------
+
+pub trait TSSearch<Id> {
+    type Result;
+}
+
+impl<Id> TSSearch<Id> for () {
+    type Result = ();
+}
+impl<Id, First, Rest> TSSearch<Id> for (First, Rest)
+where
+    Id: IdIsEqual<First::Id>,
+    (First, Rest): TSInnerSearch<Id, IdEq<Id, First::Id>>,
+    First: IdGetter,
+{
+    type Result = <(First, Rest) as TSInnerSearch<Id, IdEq<Id, First::Id>>>::Result;
+}
+impl<Id, First> TSSearch<Id> for (First,)
+where
+    Id: IdIsEqual<First::Id>,
+    First: TSInnerSearch<Id, IdEq<Id, First::Id>>,
+    First: IdGetter,
+{
+    type Result = <First as TSInnerSearch<Id, IdEq<Id, First::Id>>>::Result;
+}
+
+pub trait TSInnerSearch<Id, IsMatch> {
+    type Result;
+}
+
+impl<Id, T, Tail> TSInnerSearch<Id, B1> for (T, Tail)
+where
+    T: IdGetter,
+{
+    type Result = T;
+}
+
+impl<T, Id, Tail> TSInnerSearch<Id, B0> for (T, Tail)
+where
+    T: IdGetter,
+    Id: IdIsEqual<T::Id>,
+    Tail: TSInnerSearch<Id, IdEq<Id, T::Id>>,
+{
+    type Result = Tail::Result;
+}
+impl<Id, T> TSInnerSearch<Id, B0> for T
+where
+    T: IdGetter,
+    Id: IdIsEqual<T::Id>,
+    (T, ()): IfThenElse<IdEq<Id, T::Id>>,
+{
+    type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
+}
+impl<Id, T> TSInnerSearch<Id, B1> for T
+where
+    T: IdGetter,
+    Id: IdIsEqual<T::Id>,
+    (T, ()): IfThenElse<IdEq<Id, T::Id>>,
+{
+    type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
+}
+
+// -----------------------------------------------
+// ADD
+// -----------------------------------------------
+
+pub trait TSAddToList<T> {
+    type Result;
+}
+
+impl<T, NewItem> TSAddToList<NewItem> for T
+where
+    NewItem: IdGetter,
+    T: ItemExists<NewItem::Id>,
+    T::Exists: AssertItemDoesNotExist,
+{
+    type Result = (NewItem, T);
+}
+pub trait ItemExists<Id> {
+    type Exists: Bit;
+}
+
+impl<Id> ItemExists<Id> for () {
+    type Exists = B0;
+}
+
+impl<Id, First, Rest> ItemExists<Id> for (First, Rest)
+where
+    Id: IdIsEqual<First::Id>,
+    First: IdGetter,
+    Rest: ItemExists<Id>,
+    IdEq<Id, First::Id>: BitOr<Rest::Exists>,
+    <<Id as IdIsEqual<<First as IdGetter>::Id>>::Output as BitOr<
+        <Rest as ItemExists<Id>>::Exists,
+    >>::Output: Bit,
+{
+    type Exists = Or<IdEq<Id, First::Id>, Rest::Exists>;
+}
+pub trait AssertItemDoesNotExist {}
+
+impl AssertItemDoesNotExist for B0 {}
+
+// ------------------------------------------
+// EDIT
+// ------------------------------------------
+
+pub trait TSEditItemInList<Id, NewState> {
+    type Result;
+}
+
+impl<First, Rest, Id, NewState> TSEditItemInList<Id, NewState> for (First, Rest)
+where
+    (First, Rest): TSSearch<Id>,
+    Id: IdIsEqual<First::Id>,
+    (First, Rest): ReplaceOperativeInTuple<Id, NewState, IdEq<Id, First::Id>>,
+    <(First, Rest) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
+    First: IdGetter,
+{
+    type Result =
+        <(First, Rest) as ReplaceOperativeInTuple<Id, NewState, IdEq<Id, First::Id>>>::Result;
+}
+
+pub trait ReplaceOperativeInTuple<Id, NewState, IsMatch> {
+    type Result;
+}
+impl<Id, State, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B1>
+    for (OperativeTS<Id, State>, Rest)
+{
+    type Result = (OperativeTS<Id, NewState>, Rest);
+}
+
+impl<FirstId, FirstState, Id, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B0>
+    for (OperativeTS<FirstId, FirstState>, Rest)
+where
+    Id: IdIsEqual<FirstId>,
+    Rest: ReplaceOperativeInTuple<Id, NewState, IdEq<Id, FirstId>>,
+{
+    type Result = (
+        OperativeTS<FirstId, FirstState>,
+        <Rest as ReplaceOperativeInTuple<Id, NewState, IdEq<Id, FirstId>>>::Result,
+    );
+}
+
+// ---------------------------------------------------
+// REMOVE
+// ---------------------------------------------------
+
+pub trait TSRemoveItemFromList<Id> {
+    type Result;
+}
+
+impl<First, Rest, Id> TSRemoveItemFromList<Id> for (First, Rest)
+where
+    (First, Rest): TSSearch<Id>,
+    <(First, Rest) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
+    First: IdGetter,
+    Id: IdIsEqual<First::Id>,
+    (First, Rest): RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>,
+{
+    type Result = <(First, Rest) as RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>>::Result;
+}
+
+pub trait RemoveOperativeFromTuple<Id, IsMatch> {
+    type Result;
+}
+
+impl<Id, State, Rest> RemoveOperativeFromTuple<Id, B1> for (OperativeTS<Id, State>, Rest) {
+    type Result = Rest;
+}
+
+impl<FirstId, FirstState, Id, Rest> RemoveOperativeFromTuple<Id, B0>
+    for (OperativeTS<FirstId, FirstState>, Rest)
+where
+    Id: Same<FirstId>,
+    Rest: RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>,
+{
+    type Result = (
+        OperativeTS<FirstId, FirstState>,
+        <Rest as RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>>::Result,
+    );
+}
+
+trait AddOneId {
+    type Output; // : AddOneId;
+}
+impl<A, B, C, D> AddOneId for CompId<A, B, C, D>
+where
+    A: Add<B1> + Cmp<U255> + IsEqual<U255> + Unsigned,
+    B: Add<B1> + Cmp<U255> + IsEqual<U255> + Unsigned,
+    C: Add<B1> + Cmp<U255> + IsEqual<U255> + Unsigned,
+    D: Add<B1> + Cmp<U255> + IsEqual<U255> + Unsigned,
+    (
+        CompId<UTerm, UTerm, UTerm, UTerm>,
+        CompId<<A as Add<B1>>::Output, UTerm, UTerm, UTerm>,
+    ): IfThenElse<<A as IsEqual<U255>>::Output>,
+    (
+        <(
+            CompId<U0, U0, U0, U0>,
+            CompId<<A as Add<B1>>::Output, U0, U0, U0>,
+        ) as IfThenElse<<A as IsEqual<U255>>::Output>>::Output,
+        CompId<A, <B as Add<B1>>::Output, U0, U0>,
+    ): IfThenElse<<B as IsEqual<U255>>::Output>,
+    (
+        <(
+            <(
+                CompId<U0, U0, U0, U0>,
+                CompId<<A as Add<B1>>::Output, U0, U0, U0>,
+            ) as IfThenElse<<A as IsEqual<U255>>::Output>>::Output,
+            CompId<A, <B as Add<B1>>::Output, U0, U0>,
+        ) as IfThenElse<<B as IsEqual<U255>>::Output>>::Output,
+        CompId<A, B, <C as Add<B1>>::Output, U0>,
+    ): IfThenElse<<C as IsEqual<U255>>::Output>,
+    (
+        <(
+            <(
+                <(
+                    CompId<U0, U0, U0, U0>,
+                    CompId<<A as Add<B1>>::Output, U0, U0, U0>,
+                ) as IfThenElse<<A as IsEqual<U255>>::Output>>::Output,
+                CompId<A, <B as Add<B1>>::Output, U0, U0>,
+            ) as IfThenElse<<B as IsEqual<U255>>::Output>>::Output,
+            CompId<A, B, <C as Add<B1>>::Output, U0>,
+        ) as IfThenElse<<C as IsEqual<U255>>::Output>>::Output,
+        CompId<A, B, C, <D as Add<B1>>::Output>,
+    ): IfThenElse<<D as IsEqual<U255>>::Output>,
+    // <(
+    //     <(
+    //         <(
+    //             <(CompId<U0, U0, U0, U0>, CompId<Add1<A>, U0, U0, U0>) as IfThenElse<
+    //                 Eq<A, U255>,
+    //             >>::Output,
+    //             CompId<A, Add1<B>, U0, U0>,
+    //         ) as IfThenElse<Eq<B, U255>>>::Output,
+    //         CompId<A, B, Add1<C>, U0>,
+    //     ) as IfThenElse<Eq<C, U255>>>::Output,
+    //     CompId<A, B, C, Add1<D>>,
+    // ) as IfThenElse<Eq<D, U255>>>::Output: AddOneId,
+{
+    type Output = <(
+        <(
+            <(
+                <(CompId<U0, U0, U0, U0>, CompId<Add1<A>, U0, U0, U0>) as IfThenElse<
+                    Eq<A, U255>,
+                >>::Output,
+                CompId<A, Add1<B>, U0, U0>,
+            ) as IfThenElse<Eq<B, U255>>>::Output,
+            CompId<A, B, Add1<C>, U0>,
+        ) as IfThenElse<Eq<C, U255>>>::Output,
+        CompId<A, B, C, Add1<D>>,
+    ) as IfThenElse<Eq<D, U255>>>::Output;
+}
+
+type Add1<T> = <T as Add<B1>>::Output;
+
+#[cfg(test)]
+mod tests {
+
+    use molecule_core::IdToU32;
+    use to_composite_id_macro::to_comp_id;
+
+    use super::*;
+
+    type Slot1 = SlotTS<to_comp_id!(1), P1, Z0, B1, P3, B0, B0>;
+    type Slot2 = SlotTS<to_comp_id!(2), P2, P1, B0, P3, B0, B0>;
+    type Slot3 = SlotTS<to_comp_id!(3), P3, P1, B0, P5, B0, B1>;
+    type Op1Id = to_comp_id! {1};
+    type Op2Id = to_comp_id! {2};
+    type Op3Id = to_comp_id! {3};
+    type Op1 = OperativeTS<Op1Id, (Slot1,)>;
+    type Op2 = OperativeTS<Op2Id, (Slot2,)>;
+    type Op3 = OperativeTS<Op3Id, (Slot3,)>;
+
+    #[test]
+    fn test_search() {
+        assert_eq!(
+            <<(Op1, Op2) as TSSearch<Op1Id>>::Result as IdGetter>::Id::to_u32(),
+            1
+        );
+        assert_eq!(
+            <<(Op1, Op2) as TSSearch<Op2Id>>::Result as IdGetter>::Id::to_u32(),
+            2
+        );
+
+        let result = <<() as TSSearch<to_comp_id!(42)>>::Result as IdGetter>::Id::to_i32();
+        assert_eq!(result, -1);
+
+        // Test searching in a single-element tuple
+        assert_eq!(
+            <<(Op1,) as TSSearch<Op1Id>>::Result as IdGetter>::Id::to_u32(),
+            1
+        );
+    }
+    #[test]
+    fn test_fulfilled_slot_ts() {
+        // Valid slots
+        assert_eq!(<Slot1 as FulfilledSlotTS>::IMPLEMENTED, true);
+        assert_eq!(<Slot2 as FulfilledSlotTS>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_fulfilled_slot_tuple_ts() {
+        // Valid tuples
+        assert_eq!(<(Slot1,) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+        assert_eq!(<(Slot1, Slot2) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+
+        assert_eq!(
+            <(Slot1, Slot2, Slot3) as FulfilledSlotTupleTS>::IMPLEMENTED,
+            true
+        );
+    }
+
+    #[test]
+    fn test_slot_can_add_one() {
+        // Can add one
+        assert_eq!(<Slot1 as SlotCanAddOne>::IMPLEMENTED, true);
+
+        // Cannot add one (at max)
+        // Uncomment to verify compilation error
+
+        // type SlotAtMax = SlotTS<P89, P3, Z0, B1, P3, B0, B0>;
+        // assert_eq!(<SlotAtMax as SlotCanAddOne>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_slot_can_subtract_one() {
+        // Can subtract one
+        assert_eq!(<Slot2 as SlotCanSubtractOne>::IMPLEMENTED, true);
+
+        // Cannot subtract one (at min)
+        // Uncomment to verify compilation error
+
+        // type SlotAtMin = SlotTS<P99, P1, P1, B0, P3, B0, B0>;
+        // assert_eq!(<SlotAtMin as SlotCanSubtractOne>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_ts_add_operative() {
+        type InitialState = (Op1, ());
+
+        type NewState = <InitialState as TSAddToList<Op2>>::Result;
+        assert_eq!(
+            <<NewState as TSSearch<Op2Id>>::Result as IdGetter>::Id::to_u32(),
+            2
+        );
+
+        type NewState2 = <NewState as TSAddToList<Op3>>::Result;
+        assert_eq!(
+            <<NewState2 as TSSearch<Op3Id>>::Result as IdGetter>::Id::to_u32(),
+            3
+        );
+
+        // Adding the same operative again should not compile
+        // Uncomment to verify compilation error
+        // For some reason you have to use the type for the error to appear, so uncomment the print as well
+
+        // type InvalidState = <NewState2 as TSAddToList<Op1>>::Result;
+        // println!("{}", std::any::type_name::<InvalidState>());
+    }
+
+    #[test]
+    fn test_ts_edit_operative() {
+        type InitialState = (Op1, (Op2, (Op3, ())));
+        type EditedState = <InitialState as TSEditItemInList<Op1Id, (Slot3,)>>::Result;
+
+        // Ensure the state was edited correctly
+        assert_eq!(
+            <<<<EditedState as TSSearch<Op1Id>>::Result as StateGetter>::State as TSSearch<
+                to_comp_id!(3),
+            >>::Result as IdGetter>::Id::to_u32(),
+            3
+        );
+        assert_eq!(
+            <<<<EditedState as TSSearch<Op1Id>>::Result as StateGetter>::State as TSSearch<
+                to_comp_id!(1),
+            >>::Result as IdGetter>::Id::to_i32(),
+            -1
+        );
+    }
+    #[test]
+    fn create_tracking_graph_type() {
+        fn print_type_of<T>(_: &T)
+        where
+            T: GetCurrent,
+            T::Output: IdToU32,
+        {
+            println!("{}", std::any::type_name::<T::Output>());
+            println!("{}", T::Output::to_u32());
+        }
+        struct GraphTypestateContainer<Current, State>(PhantomData<(Current, State)>);
+        impl<Current, State> GraphTypestateContainer<Current, State>
+        where
+            Current: AddOneId,
+            AddUno<Current>: AddOneId,
+        {
+            fn add_node<NewNode>(
+                self,
+            ) -> GraphTypestateContainer<AddUno<Current>, (NewNode, State)> {
+                GraphTypestateContainer(PhantomData)
+            }
+        }
+        trait GetCurrent {
+            type Output;
+        }
+        impl<Current, State> GetCurrent for GraphTypestateContainer<Current, State> {
+            type Output = Current;
+        }
+
+        type TestId = CompId<U0, U0, U0, U1>;
+        let inst = GraphTypestateContainer::<TestId, ()>(PhantomData);
+
+        let inst = inst.add_node::<()>();
+        print_type_of(&inst);
+        panic!();
+    }
+}
+
+type AddUno<Lhs> = <Lhs as AddOneId>::Output;
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    fn test() {
+///        type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
+///        assert_eq!(<InvalidSlot as FulfilledSlotTS>::IMPLEMENTED, true);
+///    }
+/// ```
+fn test_unfulfilled_slot() {}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
+///    fn test() {
+///         type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
+///         assert_eq!(<(Slot1, InvalidSlot) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+///    }
+/// ```
+fn test_unfulfilled_slot_tuple() {}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
+///    type Slot2 = SlotTS<P2, P1, B0, P3, B0, B0>;
+///    type Op1 = OperativeTS<P1, (Slot1,)>;
+///    type Op2 = OperativeTS<P2, (Slot2,)>;
+///    fn test() {
+///         let _result = <<(Op1, Op2) as Search<U3>>::Result as IdGetter>::Id::to_u32();
+///    }
+/// ```
+fn test_failed_search() {}
 
 pub trait FulfilledSlotTupleTS {
     const IMPLEMENTED: bool = true;
@@ -326,372 +899,3 @@ where
     J: FulfilledSlotTS,
 {
 }
-
-// ------------------------------------
-struct SlotId<const ID: u32>;
-
-pub struct OperativeTS<Id, State>(PhantomData<(Id, State)>);
-
-pub trait IdAndStateGetter {
-    type Id;
-    type State;
-}
-
-impl<Id, State> IdAndStateGetter for OperativeTS<Id, State> {
-    type Id = Id;
-    type State = State;
-}
-
-pub trait IfThenElse<Condition: Bit> {
-    type Output;
-}
-
-impl<T, F> IfThenElse<B1> for (T, F) {
-    type Output = T;
-}
-impl<T, F> IfThenElse<B0> for (T, F) {
-    type Output = F;
-}
-
-impl IdAndStateGetter for () {
-    type Id = N1;
-    type State = N1;
-}
-
-// --------------------------------------
-// FIND
-// --------------------------------------
-
-pub trait TSInnerSearch<Id, IsMatch> {
-    type Result;
-}
-
-impl<Id, T, Tail> TSInnerSearch<Id, B1> for (T, Tail)
-where
-    T: IdAndStateGetter,
-{
-    type Result = T;
-}
-
-impl<T, Id, Tail> TSInnerSearch<Id, B0> for (T, Tail)
-where
-    T: IdAndStateGetter,
-    Id: IsEqual<T::Id>,
-    Tail: TSInnerSearch<Id, Eq<Id, T::Id>>,
-{
-    type Result = Tail::Result;
-}
-impl<Id, T> TSInnerSearch<Id, B0> for T
-where
-    T: IdAndStateGetter,
-    Id: IsEqual<T::Id>,
-    (T, ()): IfThenElse<Eq<Id, T::Id>>,
-{
-    type Result = <(T, ()) as IfThenElse<Eq<Id, T::Id>>>::Output;
-}
-impl<Id, T> TSInnerSearch<Id, B1> for T
-where
-    T: IdAndStateGetter,
-    Id: IsEqual<T::Id>,
-    (T, ()): IfThenElse<Eq<Id, T::Id>>,
-{
-    type Result = <(T, ()) as IfThenElse<Eq<Id, T::Id>>>::Output;
-}
-
-pub trait TSSearch<Id> {
-    type Result;
-}
-
-impl<Id> TSSearch<Id> for () {
-    type Result = ();
-}
-impl<Id, First, Rest> TSSearch<Id> for (First, Rest)
-where
-    Id: IsEqual<First::Id>,
-    (First, Rest): TSInnerSearch<Id, Eq<Id, First::Id>>,
-    First: IdAndStateGetter,
-{
-    type Result = <(First, Rest) as TSInnerSearch<Id, Eq<Id, First::Id>>>::Result;
-}
-impl<Id, First> TSSearch<Id> for (First,)
-where
-    Id: IsEqual<First::Id>,
-    First: TSInnerSearch<Id, Eq<Id, First::Id>>,
-    First: IdAndStateGetter,
-{
-    type Result = <First as TSInnerSearch<Id, Eq<Id, First::Id>>>::Result;
-}
-
-// -----------------------------------------------
-// ADD
-// -----------------------------------------------
-
-pub trait TSAddOperative<T> {
-    type Result;
-}
-
-// impl<GTS, NewOperative> TSAddOperative<NewOperative> for (NewOperative, GTS)
-// where
-//     NewOperative: IdGetter,
-//     // GTS: Search<NewOperative::Id>,
-//     // <GTS as Search<NewOperative::Id>>::Result: IsEqual<B0>,
-// {
-//     type Result = (NewOperative, GTS);
-// }
-impl<GTS, NewOperative> TSAddOperative<NewOperative> for GTS
-where
-    NewOperative: IdAndStateGetter,
-    // GTS: Search<NewOperative::Id>,
-    // <GTS as Search<NewOperative::Id>>::Result: IsEqual<B0>,
-{
-    type Result = (NewOperative, GTS);
-}
-
-// ------------------------------------------
-// edit
-// ------------------------------------------
-
-pub trait TSEditOperative<Id, NewState> {
-    type Result;
-}
-
-impl<First, Rest, Id, NewState> TSEditOperative<Id, NewState> for (First, Rest)
-where
-    (First, Rest): TSSearch<Id>,
-    Id: IsEqual<First::Id>,
-    (First, Rest): ReplaceOperativeInTuple<Id, NewState, Eq<Id, First::Id>>,
-    <(First, Rest) as TSSearch<Id>>::Result: IdAndStateGetter<Id = Id>,
-    First: IdAndStateGetter,
-{
-    type Result =
-        <(First, Rest) as ReplaceOperativeInTuple<Id, NewState, Eq<Id, First::Id>>>::Result;
-}
-
-pub trait ReplaceOperativeInTuple<Id, NewState, IsMatch> {
-    type Result;
-}
-impl<Id, State, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B1>
-    for (OperativeTS<Id, State>, Rest)
-{
-    type Result = (OperativeTS<Id, NewState>, Rest);
-}
-
-impl<FirstId, FirstState, Id, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B0>
-    for (OperativeTS<FirstId, FirstState>, Rest)
-where
-    Id: IsEqual<FirstId>,
-    Rest: ReplaceOperativeInTuple<Id, NewState, Eq<Id, FirstId>>,
-{
-    type Result = (
-        OperativeTS<FirstId, FirstState>,
-        <Rest as ReplaceOperativeInTuple<Id, NewState, Eq<Id, FirstId>>>::Result,
-    );
-}
-
-// ---------------------------------------------------
-// REMOVE
-// ---------------------------------------------------
-
-pub trait TSRemoveOperative<T> {
-    type Result;
-}
-
-impl<First, Rest, Id> TSRemoveOperative<Id> for (First, Rest)
-where
-    (First, Rest): TSSearch<Id>,
-    <(First, Rest) as TSSearch<Id>>::Result: IdAndStateGetter<Id = Id>,
-    First: IdAndStateGetter,
-    Id: IsEqual<First::Id>,
-    (First, Rest): RemoveOperativeFromTuple<Id, Eq<Id, First::Id>>,
-{
-    type Result = <(First, Rest) as RemoveOperativeFromTuple<Id, Eq<Id, First::Id>>>::Result;
-}
-
-pub trait RemoveOperativeFromTuple<Id, IsMatch> {
-    type Result;
-}
-
-impl<Id, State, Rest> RemoveOperativeFromTuple<Id, B1> for (OperativeTS<Id, State>, Rest) {
-    type Result = Rest;
-}
-
-impl<FirstId, FirstState, Id, Rest> RemoveOperativeFromTuple<Id, B0>
-    for (OperativeTS<FirstId, FirstState>, Rest)
-where
-    Id: Same<FirstId>,
-    Rest: RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>,
-{
-    type Result = (
-        OperativeTS<FirstId, FirstState>,
-        <Rest as RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>>::Result,
-    );
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::post_generation::reactive::RGSO;
-
-    use super::*;
-    use typenum::*;
-
-    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
-    type Slot2 = SlotTS<P2, P1, B0, P3, B0, B0>;
-    type Slot3 = SlotTS<P3, P1, B0, P5, B0, B1>;
-    type Op1 = OperativeTS<P1, (Slot1,)>;
-    type Op2 = OperativeTS<P2, (Slot2,)>;
-    type Op3 = OperativeTS<P3, (Slot3, Slot1)>;
-
-    #[test]
-    fn test_search() {
-        assert_eq!(
-            <<(Op1, Op2) as TSSearch<P1>>::Result as IdAndStateGetter>::Id::to_i32(),
-            1
-        );
-        assert_eq!(
-            <<(Op1, Op2) as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
-            2
-        );
-
-        let result = <<() as TSSearch<U1>>::Result as IdAndStateGetter>::Id::to_i32();
-        assert_eq!(result, -1);
-
-        // Test searching in a single-element tuple
-        assert_eq!(
-            <<(Op1,) as TSSearch<P1>>::Result as IdAndStateGetter>::Id::to_i32(),
-            1
-        );
-    }
-    #[test]
-    fn test_fulfilled_slot_ts() {
-        // Valid slots
-        assert_eq!(<Slot1 as FulfilledSlotTS>::IMPLEMENTED, true);
-        assert_eq!(<Slot2 as FulfilledSlotTS>::IMPLEMENTED, true);
-    }
-
-    #[test]
-    fn test_fulfilled_slot_tuple_ts() {
-        // Valid tuples
-        assert_eq!(<(Slot1,) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
-        assert_eq!(<(Slot1, Slot2) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
-
-        assert_eq!(
-            <(Slot1, Slot2, Slot3) as FulfilledSlotTupleTS>::IMPLEMENTED,
-            true
-        );
-    }
-
-    #[test]
-    fn test_slot_can_add_one() {
-        // Can add one
-        assert_eq!(<Slot1 as SlotCanAddOne>::IMPLEMENTED, true);
-
-        // Cannot add one (at max)
-        type SlotAtMax = SlotTS<P3, Z0, B1, P3, B0, B0>;
-        // Uncomment to verify compilation error
-        // assert_eq!(<SlotAtMax as SlotCanAddOne>::IMPLEMENTED, true);
-    }
-
-    #[test]
-    fn test_slot_can_subtract_one() {
-        // Can subtract one
-        assert_eq!(<Slot2 as SlotCanSubtractOne>::IMPLEMENTED, true);
-
-        // Cannot subtract one (at min)
-        type SlotAtMin = SlotTS<P1, P1, B0, P3, B0, B0>;
-        // Uncomment to verify compilation error
-        // assert_eq!(<SlotAtMin as SlotCanSubtractOne>::IMPLEMENTED, true);
-    }
-
-    #[test]
-    fn test_ts_add_operative() {
-        type InitialState = (Op1,);
-        type NewState = <InitialState as TSAddOperative<Op2>>::Result;
-
-        // Ensure the new state includes Op1
-        assert_eq!(
-            <<NewState as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
-            2
-        );
-
-        type NewState2 = <InitialState as TSAddOperative<Op3>>::Result;
-        assert_eq!(
-            <<NewState2 as TSSearch<P3>>::Result as IdAndStateGetter>::Id::to_i32(),
-            3
-        );
-        // Adding the same operative again should not compile
-        // Uncomment to verify compilation error
-        // type InvalidState = <NewState as TSAddOperative<Op1>>::Result;
-    }
-
-    // #[test]
-    // fn test_ts_edit_operative() {
-    //     type InitialState = (Op1, Op2);
-    //     type NewOp1 = OperativeTS<P1, (P2,)>;
-    //     // type NewOp2 = OperativeTS<P1, (P1,)>;
-    //     type EditedState = <InitialState as TSEditOperative<P1, (P3,)>>::Result;
-
-    //     // Ensure the state was edited correctly
-    //     assert_eq!(
-    //         <<EditedState as TSSearch<P1>>::Result as SlotTSMarker>::CountIsLessThanMax::to_bool(),
-    //         false
-    //     );
-    //     // You might need to add more specific checks here to ensure the state was updated correctly
-    // }
-
-    // #[test]
-    // fn test_ts_remove_operative() {
-    //     type InitialState = RBaseGraphEnvironmentWithTypestate<DummySchema, (Op1, Op2)>;
-    //     type RemovedState = <InitialState as TSRemoveOperative<P1>>::Result;
-
-    //     // Ensure Op1 was removed
-    //     // This should not compile if Op1 was successfully removed
-    //     // Uncomment to verify compilation error
-    //     // let _result = <<RemovedState as Search<P1>>::Result as IdGetter>::Id::to_i32();
-
-    //     // Ensure Op2 is still present
-    //     assert_eq!(
-    //         <<RemovedState as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
-    //         2
-    //     );
-    // }
-}
-
-#[allow(dead_code)]
-#[doc(hidden)]
-/// ```compile_fail
-///    use typenum::*;
-///    use base_types::post_generation::type_level::*;
-///    fn test() {
-///        type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
-///        assert_eq!(<InvalidSlot as FulfilledSlotTS>::IMPLEMENTED, true);
-///    }
-/// ```
-fn test_unfulfilled_slot() {}
-
-#[allow(dead_code)]
-#[doc(hidden)]
-/// ```compile_fail
-///    use typenum::*;
-///    use base_types::post_generation::type_level::*;
-///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
-///    fn test() {
-///         type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
-///         assert_eq!(<(Slot1, InvalidSlot) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
-///    }
-/// ```
-fn test_unfulfilled_slot_tuple() {}
-
-#[allow(dead_code)]
-#[doc(hidden)]
-/// ```compile_fail
-///    use typenum::*;
-///    use base_types::post_generation::type_level::*;
-///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
-///    type Slot2 = SlotTS<P2, P1, B0, P3, B0, B0>;
-///    type Op1 = OperativeTS<P1, (Slot1,)>;
-///    type Op2 = OperativeTS<P2, (Slot2,)>;
-///    fn test() {
-///         let _result = <<(Op1, Op2) as Search<U3>>::Result as IdGetter>::Id::to_i32();
-///    }
-/// ```
-fn test_failed_search() {}

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -1,8 +1,8 @@
-// use std::{
-//     marker::PhantomData,
-//     ops::{Add, Sub},
-// };
-// use typenum::*;
+use std::{
+    marker::PhantomData,
+    ops::{Add, BitAnd, BitOr, Sub},
+};
+use typenum::*;
 
 // // Trait to represent the graph system's traits
 // trait GraphTrait {}
@@ -14,7 +14,118 @@
 // }
 
 // // Slot types with min and max
-// struct Slot<Name, Count, Min, Max, Traits>(PhantomData<(Name, Count, Min, Max, Traits)>);
+
+// pub type Infinity = U1024;
+pub type NonExistent = P9;
+
+pub trait SlotTSMarker {
+    // const FULFILLS_UPPER_BOUND: bool;
+    // const FULFILLS_LOWER_BOUND: bool;
+    type Count: Integer + IsGreaterOrEqual<Self::Min> + IsLessOrEqual<Self::Max> + IsGreater<Z0>;
+    // + std::ops::Add<B1>
+    // + std::ops::Sub<B1>
+    // + typenum::Cmp<Self::Max>
+    // + typenum::Cmp<Self::Min>
+    // + typenum::Cmp<Z0>
+    // + typenum::private::IsEqualPrivate<
+    //     typenum::Z0,
+    //     <Self::Count as typenum::Cmp<typenum::Z0>>::Output,
+    // > + typenum::private::IsGreaterOrEqualPrivate<
+    //     Self::Min,
+    //     <Self::Count as typenum::Cmp<Self::Min>>::Output,
+    // > + typenum::private::IsLessOrEqualPrivate<
+    //     Self::Max,
+    //     <Self::Count as typenum::Cmp<Self::Max>>::Output,
+    // >;
+    type Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>;
+    type Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>;
+    type ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>;
+    // type IsFulfilled: Bit;
+    // type CanAddOne: Bit;
+    // type CanSubtractOne: Bit;
+    type MaxIsNonExistent: Bit;
+    type MinIsNonExistent: Bit;
+    type CountIsGreaterThanOrEqualToMin: Bit;
+    type CountIsGreaterThanZero: Bit;
+    type CountIsLessThanOrEqualToMax: Bit;
+}
+pub struct SlotTS<
+    Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+    // + std::ops::Add<B1>
+    // + std::ops::Sub<B1>
+    // + typenum::Cmp<Max>
+    // + typenum::Cmp<Min>
+    // + typenum::Cmp<Z0>
+    // + typenum::private::IsEqualPrivate<typenum::Z0, <Count as typenum::Cmp<typenum::Z0>>::Output>
+    // + typenum::private::IsGreaterOrEqualPrivate<Min, <Count as typenum::Cmp<Min>>::Output>
+    // + typenum::private::IsLessOrEqualPrivate<Max, <Count as typenum::Cmp<Max>>::Output>,
+    Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>,
+    Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent> + typenum::Cmp<Count>,
+    ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>,
+>(PhantomData<(Count, Min, Max, ZeroAllowed)>);
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        // + std::ops::Add<B1>
+        // + std::ops::Sub<B1>
+        // + typenum::Cmp<Max>
+        // + typenum::Cmp<Min>
+        // + typenum::Cmp<Z0>
+        // + typenum::private::IsEqualPrivate<
+        //     typenum::Z0,
+        //     <Count as typenum::Cmp<typenum::Z0>>::Output,
+        // > + typenum::private::IsGreaterOrEqualPrivate<Min, <Count as typenum::Cmp<Min>>::Output>
+        // + typenum::private::IsLessOrEqualPrivate<Max, <Count as typenum::Cmp<Max>>::Output>,
+        Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>,
+        Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent> + typenum::Cmp<Count>,
+        ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>,
+    > SlotTSMarker for SlotTS<Count, Min, Max, ZeroAllowed>
+{
+    type Count = Count;
+    type Min = Min;
+    type Max = Max;
+    type ZeroAllowed = ZeroAllowed;
+    // type IsFulfilled = op!(((Count <= Max) | (Max == NonExistent))
+    //     & ((Count >= Min) | ((Count == Z0) & (ZeroAllowed == B1)) | (Min == NonExistent)));
+    // type IsFulfilled = op!(((P1 <= P3) | (P3 == NonExistent))
+    //     & ((P1 >= P1) | ((P1 == Z0) & (ZeroAllowed == B1)) | (P1 == NonExistent)));
+    // const FULFILLS_UPPER_BOUND: bool = Count::I32 <= Max::I32 || Max::I32 == NonExistent::I32;
+    // const FULFILLS_LOWER_BOUND: bool = Count::I32 >= Min::I32
+    //     || (Count::I32 == 0 && ZeroAllowed::BOOL)
+    //     || Min::I32 == NonExistent::I32;
+    // type CountIsLessThanOrEqualToMax = <Count as IsLessOrEqual<Max>>::Output;
+    type MaxIsNonExistent = Eq<Max, NonExistent>;
+    type MinIsNonExistent = Eq<Max, NonExistent>;
+    type CountIsGreaterThanOrEqualToMin = GrEq<Count, Min>;
+    type CountIsLessThanOrEqualToMax = LeEq<Count, Max>;
+    type CountIsGreaterThanZero = Gr<Count, Z0>;
+    // type MaxIsNonExistent = op!(Max == NonExistent);
+    // type IsFulfilled = <Self::CountIsLessThanOrEqualToMax as BitOr<Self::MaxIsNonExistent>>::Output; //Self::MaxIsNonExistent); // | (Max == NonExistent));
+    // type IsFulfilled = Or<Self::CountIsLessThanOrEqualToMax, Self::MaxIsNonExistent>;
+    // type CanAddOne = op!((Self::MaxIsNonExistent == B1) | (Count + B1 <= Max));
+    // type CanSubtractOne =
+    //     op!(Min == NonExistent | Count - B1 >= Min | (Count >= Z0 & ZeroAllowed == B1));
+
+    // const FULFILLS_UPPER_BOUND: bool = Count::I32 <= Max::I32 || Max::I32 == NonExistent::I32;
+    // const FULFILLS_LOWER_BOUND: bool = Count::I32 >= Min::I32
+    //     || (Count::I32 == 0 && ZeroAllowed::BOOL)
+    //     || Min::I32 == NonExistent::I32;
+    // pub const IS_FULFILLED: bool = Self::FULFILLS_UPPER_BOUND && Self::FULFILLS_LOWER_BOUND;
+    // pub const CAN_ADD_ONE: bool = if Max::I32 == NonExistent::I32 {
+    //     true
+    // } else {
+    //     Count::I32 + 1 <= Max::I32
+    // };
+    // /// Allow subtraction if subtracting one would leave the count within the min or if zero is allowed and the count is greater than zero
+    // pub const CAN_SUBTRACT_ONE: bool = if NonExistent::I32 == Min::I32 {
+    //     if Count::I32 == 0 {
+    //         false
+    //     } else {
+    //         true
+    //     }
+    // } else {
+    //     Count::I32 - 1 >= Min::I32 || (Count::I32 > 0 && ZeroAllowed::BOOL)
+    // };
+}
 
 // // Trait to modify a specific slot
 // trait ModifySlot<Name, Op> {

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -395,20 +395,6 @@ where
     type Result =
         <(First, Rest) as TSInnerSearch<Id, IdEq<Id, First::Id>, IdEq<Id, Rest::Id>>>::Result;
 }
-// impl<Id, First, Second, Rest> TSSearch<Id> for (First, (Second, Rest))
-// where
-//     Id: IdIsEqual<First::Id>,
-//     Id: IdIsEqual<Second::Id>,
-//     (First, (Second, Rest)): TSInnerSearch<Id, IdEq<Id, First::Id>, IdEq<Id, Second::Id>>,
-//     First: IdGetter,
-//     Second: IdGetter,
-// {
-//     type Result = <(First, (Second, Rest)) as TSInnerSearch<
-//         Id,
-//         IdEq<Id, First::Id>,
-//         IdEq<Id, Second::Id>,
-//     >>::Result;
-// }
 
 impl<Id, First> TSSearch<Id> for (First,)
 where
@@ -446,22 +432,9 @@ where
 {
     type Result = <(Second, Tail) as TSInnerSearch<Id, B0, IdEq<Id, Tail::Id>>>::Result;
 }
-// impl<Id, T, NextMatch> TSInnerSearch<Id, B0, NextMatch> for T
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
-// impl<Id, T, NextMatch> TSInnerSearch<Id, B1, NextMatch> for T
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
+impl<First, Id> TSInnerSearch<Id, B0, B0> for (First, ()) {
+    type Result = ();
+}
 impl<Id, T, NextMatch> TSInnerSearch<Id, B1, NextMatch> for (T,)
 where
     T: IdGetter,
@@ -478,81 +451,6 @@ where
 {
     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
 }
-// pub trait TSSearch<Id> {
-//     type Result;
-// }
-
-// impl<Id> TSSearch<Id> for () {
-//     type Result = ();
-// }
-// impl<Id, First, Rest> TSSearch<Id> for (First, Rest)
-// where
-//     Id: IdIsEqual<First::Id>,
-//     (First, Rest): TSInnerSearch<Id, IdEq<Id, First::Id>>,
-//     First: IdGetter,
-// {
-//     type Result = <(First, Rest) as TSInnerSearch<Id, IdEq<Id, First::Id>>>::Result;
-// }
-// impl<Id, First> TSSearch<Id> for (First,)
-// where
-//     Id: IdIsEqual<First::Id>,
-//     First: TSInnerSearch<Id, IdEq<Id, First::Id>>,
-//     First: IdGetter,
-// {
-//     type Result = <First as TSInnerSearch<Id, IdEq<Id, First::Id>>>::Result;
-// }
-
-// pub trait TSInnerSearch<Id, IsMatch> {
-//     type Result;
-// }
-
-// impl<Id, T, Tail> TSInnerSearch<Id, B1> for (T, Tail)
-// where
-//     T: IdGetter,
-// {
-//     type Result = T;
-// }
-
-// impl<T, Id, Tail> TSInnerSearch<Id, B0> for (T, Tail)
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     Tail: TSInnerSearch<Id, IdEq<Id, T::Id>>,
-// {
-//     type Result = Tail::Result;
-// }
-// impl<Id, T> TSInnerSearch<Id, B0> for T
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
-// impl<Id, T> TSInnerSearch<Id, B1> for T
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
-// impl<Id, T> TSInnerSearch<Id, B1> for (T,)
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
-// impl<Id, T> TSInnerSearch<Id, B0> for (T,)
-// where
-//     T: IdGetter,
-//     Id: IdIsEqual<T::Id>,
-//     (T, ()): IfThenElse<IdEq<Id, T::Id>>,
-// {
-//     type Result = <(T, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
-// }
 
 // -----------------------------------------------
 // ADD
@@ -598,212 +496,150 @@ impl AssertItemDoesNotExist for B0 {}
 // EDIT
 // ------------------------------------------
 
-pub trait TSEditItemInList<Id, NewState> {
+pub trait TSEdit<Id, NewState> {
     type Result;
 }
 
-impl<Id, First, Tail, NewState> TSEditItemInList<Id, NewState> for (First, Tail)
-where
-    Id: IdIsEqual<First::Id>,
-    (First, Tail): TSInnerEdit<Id, NewState, IdEq<Id, First::Id>>,
-    First: IdGetter,
-{
-    type Result = <(First, Tail) as TSInnerEdit<Id, NewState, IdEq<Id, First::Id>>>::Result;
+impl<Id, NewState> TSEdit<Id, NewState> for () {
+    type Result = ();
 }
-impl<Id, First, NewState> TSEditItemInList<Id, NewState> for (First,)
+impl<Id, First, Rest, NewState> TSEdit<Id, NewState> for (First, Rest)
 where
     Id: IdIsEqual<First::Id>,
-    First: TSInnerEdit<Id, NewState, IdEq<Id, First::Id>>,
+    Id: IdIsEqual<Rest::Id>,
+    (First, Rest): TSInnerEdit<Id, IdEq<Id, First::Id>, IdEq<Id, Rest::Id>, NewState>,
     First: IdGetter,
+    Rest: IdGetter,
 {
-    type Result = (<First as TSInnerEdit<Id, NewState, IdEq<Id, First::Id>>>::Result,);
+    type Result = <(First, Rest) as TSInnerEdit<
+        Id,
+        IdEq<Id, First::Id>,
+        IdEq<Id, Rest::Id>,
+        NewState,
+    >>::Result;
 }
 
-pub trait TSInnerEdit<Id, NewState, IsMatch> {
+impl<Id, First, NewState> TSEdit<Id, NewState> for (First,)
+where
+    Id: IdIsEqual<First::Id>,
+    (First,): TSInnerEdit<Id, IdEq<Id, First::Id>, B0, NewState>,
+    First: IdGetter,
+{
+    type Result = <(First,) as TSInnerEdit<Id, IdEq<Id, First::Id>, B0, NewState>>::Result;
+}
+
+pub trait TSInnerEdit<Id, IsMatch, IsNextMatch, NewState> {
     type Result;
 }
 
-impl<Id, T, Tail, NewState> TSInnerEdit<Id, NewState, B1> for (T, Tail)
+impl<Id, T, Tail, NextMatch, NewState> TSInnerEdit<Id, B1, NextMatch, NewState> for (T, Tail)
 where
     T: IdGetter,
 {
     type Result = (OperativeTS<Id, NewState>, Tail);
 }
 
-impl<T, Id, Tail, NewState> TSInnerEdit<Id, NewState, B0> for (T, Tail)
+impl<T, Id, Tail, NewState> TSInnerEdit<Id, B0, B1, NewState> for (T, Tail)
 where
     T: IdGetter,
     Id: IdIsEqual<T::Id>,
-    Tail: TSInnerEdit<Id, NewState, IdEq<Id, T::Id>>,
+    Tail: TSInnerEdit<Id, B1, B0, NewState>,
 {
     type Result = (T, Tail::Result);
 }
-impl<Id, T, NewState> TSInnerEdit<Id, NewState, B0> for T
+impl<First, Second, Id, Tail, NewState> TSInnerEdit<Id, B0, B0, NewState>
+    for (First, (Second, Tail))
 where
-    T: IdGetter,
-    Id: IdIsEqual<T::Id>,
-    (OperativeTS<Id, NewState>, ()): IfThenElse<IdEq<Id, T::Id>>,
+    Tail: IdGetter,
+    Id: IdIsEqual<Tail::Id>,
+    (Second, Tail): TSInnerEdit<Id, B0, IdEq<Id, Tail::Id>, NewState>,
 {
-    type Result = <(OperativeTS<Id, NewState>, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
+    type Result = (
+        First,
+        <(Second, Tail) as TSInnerEdit<Id, B0, IdEq<Id, Tail::Id>, NewState>>::Result,
+    );
 }
-impl<Id, NewState, T> TSInnerEdit<Id, NewState, B1> for T
-where
-    T: IdGetter,
-    Id: IdIsEqual<T::Id>,
-    (OperativeTS<Id, NewState>, ()): IfThenElse<IdEq<Id, T::Id>>,
-{
-    type Result = <(OperativeTS<Id, NewState>, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output;
+impl<First, Id, NewState> TSInnerEdit<Id, B0, B0, NewState> for (First, ()) {
+    type Result = (First, ());
 }
-impl<Id, NewState, T> TSInnerEdit<Id, NewState, B1> for (T,)
-where
-    T: IdGetter,
-    Id: IdIsEqual<T::Id>,
-    (OperativeTS<Id, NewState>, ()): IfThenElse<IdEq<Id, T::Id>>,
-{
-    type Result = (<(OperativeTS<Id, NewState>, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output,);
+impl<Id, T, NextMatch, NewState> TSInnerEdit<Id, B1, NextMatch, NewState> for (T,) {
+    type Result = (OperativeTS<Id, NewState>,);
 }
-impl<Id, NewState, T> TSInnerEdit<Id, NewState, B0> for (T,)
-where
-    T: IdGetter,
-    Id: IdIsEqual<T::Id>,
-    (OperativeTS<Id, NewState>, ()): IfThenElse<IdEq<Id, T::Id>>,
-{
-    type Result = (<(OperativeTS<Id, NewState>, ()) as IfThenElse<IdEq<Id, T::Id>>>::Output,);
+impl<Id, T, NextMatch, NewState> TSInnerEdit<Id, B0, NextMatch, NewState> for (T,) {
+    type Result = ();
 }
-// pub trait TSEditItemInList<Id, NewState> {
-//     type Result;
-// }
-
-// impl<First, Rest, Id, NewState> TSEditItemInList<Id, NewState> for (First, Rest)
-// where
-//     (First, Rest): TSSearch<Id>,
-//     Id: IdIsEqual<First::Id>,
-//     (First, Rest): ReplaceOperativeInTuple<Id, NewState, IdEq<Id, First::Id>>,
-//     // <(First, Rest) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
-//     First: IdGetter,
-// {
-//     type Result =
-//         <(First, Rest) as ReplaceOperativeInTuple<Id, NewState, IdEq<Id, First::Id>>>::Result;
-// }
-// impl<First, Id, NewState> TSEditItemInList<Id, NewState> for (First,)
-// where
-//     Id: IdIsEqual<First::Id>,
-//     First: IdGetter,
-// {
-//     type Result = (OperativeTS<Id, NewState>,);
-// }
-
-// pub trait ReplaceOperativeInTuple<Id, NewState, IsMatch> {
-//     type Result;
-// }
-// impl<Id, State, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B1>
-//     for (OperativeTS<Id, State>, Rest)
-// {
-//     type Result = (OperativeTS<Id, NewState>, Rest);
-// }
-
-// impl<FirstId, FirstState, Id, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B0>
-//     for (OperativeTS<FirstId, FirstState>, Rest)
-// where
-//     Id: IdIsEqual<FirstId>,
-//     Rest: ReplaceOperativeInTuple<Id, NewState, IdEq<Id, FirstId>>,
-// {
-//     type Result = (
-//         OperativeTS<FirstId, FirstState>,
-//         <Rest as ReplaceOperativeInTuple<Id, NewState, IdEq<Id, FirstId>>>::Result,
-//     );
-// }
 
 // ---------------------------------------------------
 // REMOVE
 // ---------------------------------------------------
 
-pub trait TSRemoveItemFromList<Id> {
+pub trait TSRemove<Id> {
     type Result;
 }
 
-impl<First, Rest, Id> TSRemoveItemFromList<Id> for (First, Rest)
-where
-    (First, Rest): TSSearch<Id>,
-    Id: IdIsEqual<First::Id>,
-    (First, Rest): RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>,
-    // <(First, Rest) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
-    First: IdGetter,
-{
-    type Result = <(First, Rest) as RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>>::Result;
-}
-impl<First, Id> TSRemoveItemFromList<Id> for (First,)
-where
-    Id: IdIsEqual<First::Id>,
-    First: IdGetter,
-{
+impl<Id> TSRemove<Id> for () {
     type Result = ();
 }
+impl<Id, First, Rest> TSRemove<Id> for (First, Rest)
+where
+    Id: IdIsEqual<First::Id>,
+    Id: IdIsEqual<Rest::Id>,
+    (First, Rest): TSInnerRemove<Id, IdEq<Id, First::Id>, IdEq<Id, Rest::Id>>,
+    First: IdGetter,
+    Rest: IdGetter,
+{
+    type Result =
+        <(First, Rest) as TSInnerRemove<Id, IdEq<Id, First::Id>, IdEq<Id, Rest::Id>>>::Result;
+}
 
-pub trait RemoveOperativeFromTuple<Id, IsMatch> {
+impl<Id, First> TSRemove<Id> for (First,)
+where
+    Id: IdIsEqual<First::Id>,
+    (First,): TSInnerRemove<Id, IdEq<Id, First::Id>, B0>,
+    First: IdGetter,
+{
+    type Result = <(First,) as TSInnerRemove<Id, IdEq<Id, First::Id>, B0>>::Result;
+}
+
+pub trait TSInnerRemove<Id, IsMatch, IsNextMatch> {
     type Result;
 }
-impl<Id, State, Rest> RemoveOperativeFromTuple<Id, B1> for (OperativeTS<Id, State>, Rest) {
-    type Result = Rest;
+
+impl<Id, T, Tail, NextMatch> TSInnerRemove<Id, B1, NextMatch> for (T, Tail)
+where
+    T: IdGetter,
+{
+    type Result = Tail;
 }
 
-impl<FirstId, FirstState, Id, Rest> RemoveOperativeFromTuple<Id, B0>
-    for (OperativeTS<FirstId, FirstState>, Rest)
+impl<T, Id, Tail> TSInnerRemove<Id, B0, B1> for (T, Tail)
 where
-    Id: IdIsEqual<FirstId>,
-    Rest: RemoveOperativeFromTuple<Id, IdEq<Id, FirstId>>,
+    T: IdGetter,
+    Id: IdIsEqual<T::Id>,
+    Tail: TSInnerRemove<Id, B1, B0>,
+{
+    type Result = (T, Tail::Result);
+}
+impl<First, Second, Id, Tail> TSInnerRemove<Id, B0, B0> for (First, (Second, Tail))
+where
+    Tail: IdGetter,
+    Id: IdIsEqual<Tail::Id>,
+    (Second, Tail): TSInnerRemove<Id, B0, IdEq<Id, Tail::Id>>,
 {
     type Result = (
-        OperativeTS<FirstId, FirstState>,
-        <Rest as RemoveOperativeFromTuple<Id, IdEq<Id, FirstId>>>::Result,
+        First,
+        <(Second, Tail) as TSInnerRemove<Id, B0, IdEq<Id, Tail::Id>>>::Result,
     );
 }
-// pub trait TSRemoveItemFromList<Id> {
-//     type Result;
-// }
-
-// impl<First, Rest, Id> TSRemoveItemFromList<Id> for (First, Rest)
-// where
-//     (First, Rest): TSSearch<Id>,
-//     <(First, Rest) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
-//     First: IdGetter,
-//     Id: IdIsEqual<First::Id>,
-//     (First, Rest): RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>,
-// {
-//     type Result = <(First, Rest) as RemoveOperativeFromTuple<Id, IdEq<Id, First::Id>>>::Result;
-// }
-// impl<Id, T> TSRemoveItemFromList<Id> for (T,)
-// where
-//     // T: IdGetter,
-//     // T::Id: Same<Id, Output = B1>,
-//     (T,): TSSearch<Id>,
-//     <(T,) as TSSearch<Id>>::Result: IdGetter<Id = Id>,
-// {
-//     type Result = ();
-// }
-// // impl<Id> TSRemoveItemFromList<Id> for () {
-// //     type Result = ();
-// // }
-
-// pub trait RemoveOperativeFromTuple<Id, IsMatch> {
-//     type Result;
-// }
-
-// impl<Id, State, Rest> RemoveOperativeFromTuple<Id, B1> for (OperativeTS<Id, State>, Rest) {
-//     type Result = Rest;
-// }
-
-// impl<FirstId, FirstState, Id, Rest> RemoveOperativeFromTuple<Id, B0>
-//     for (OperativeTS<FirstId, FirstState>, Rest)
-// where
-//     Id: Same<FirstId>,
-//     Rest: RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>,
-// {
-//     type Result = (
-//         OperativeTS<FirstId, FirstState>,
-//         <Rest as RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>>::Result,
-//     );
-// }
+impl<First, Id> TSInnerRemove<Id, B0, B0> for (First, ()) {
+    type Result = (First, ());
+}
+impl<Id, T, NextMatch> TSInnerRemove<Id, B1, NextMatch> for (T,) {
+    type Result = ();
+}
+impl<Id, T, NextMatch> TSInnerRemove<Id, B0, NextMatch> for (T,) {
+    type Result = (T,);
+}
 
 // ------------------------------------------
 // Compound ID
@@ -904,10 +740,15 @@ mod tests {
         fn print_type_of<T>(_: &T)
         where
             T: GetCurrent,
+            T: StateGetter,
             T::Output: IdToU32,
         {
-            println!("{}", std::any::type_name::<T>());
-            println!("{}", T::Output::to_u32());
+            println!("{}", std::any::type_name::<T::State>());
+            println!("---");
+            println!(
+                "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
+            );
+            // println!("{}", T::Output::to_u32());
         }
         struct GraphTypestateContainer<Current, State>(PhantomData<(Current, State)>);
         impl<Current, State> GraphTypestateContainer<Current, State> {
@@ -923,13 +764,16 @@ mod tests {
             }
             fn remove_node<Id>(
                 self,
-            ) -> GraphTypestateContainer<Current, <State as TSRemoveItemFromList<Id>>::Result>
+            ) -> GraphTypestateContainer<Current, <State as TSRemove<Id>>::Result>
             where
-                State: TSRemoveItemFromList<Id>,
+                State: TSRemove<Id>,
                 Id: IdIsEqual,
             {
                 GraphTypestateContainer(PhantomData)
             }
+        }
+        impl<Current, State> StateGetter for GraphTypestateContainer<Current, State> {
+            type State = State;
         }
         trait GetCurrent {
             type Output;
@@ -939,17 +783,20 @@ mod tests {
         }
 
         type TestId = CompId<U0, U0, U0, U1>;
-        let inst = GraphTypestateContainer::<TestId, (TestId,)>(PhantomData);
+        let inst = GraphTypestateContainer::<AddUno<TestId>, (Op1,)>(PhantomData);
         print_type_of(&inst);
 
-        // let inst = inst.add_node::<()>();
-        // print_type_of(&inst);
-        // let inst = inst.add_node::<()>();
-        // print_type_of(&inst);
-        // let inst = inst.remove_node::<AddUno<TestId>>();
-        // let inst = inst.remove_node::<AddUno<AddUno<TestId>>>();
-        // print_type_of(&inst);
-        // panic!();
+        let inst = inst.add_node::<()>();
+        print_type_of(&inst);
+        let inst = inst.add_node::<()>();
+        print_type_of(&inst);
+        let inst = inst.remove_node::<TestId>();
+        print_type_of(&inst);
+        let inst = inst.remove_node::<AddUno<TestId>>();
+        print_type_of(&inst);
+        let inst = inst.remove_node::<AddUno<AddUno<TestId>>>();
+        print_type_of(&inst);
+        panic!();
     }
 
     #[test]
@@ -981,7 +828,24 @@ mod tests {
         // Test searching for the middle element in a tuple
         assert_eq!(
             <<(Op1, (Op2, (Op3,))) as TSSearch<Op2Id>>::Result as IdGetter>::Id::to_u32(),
-            3
+            2
+        );
+        // Test searching for the a bigger tuple
+        assert_eq!(
+            <<(
+                Op1,
+                (
+                    Op2,
+                    (
+                        Op3,
+                        (
+                            OperativeTS<to_comp_id!(100), ()>,
+                            OperativeTS<to_comp_id!(20), ()>
+                        )
+                    )
+                )
+            ) as TSSearch<to_comp_id!(100)>>::Result as IdGetter>::Id::to_u32(),
+            100
         );
     }
     #[test]
@@ -1056,7 +920,7 @@ mod tests {
         type InitialState = (Op1, (Op2, (Op3,)));
 
         // Ensure the state was edited correctly for terminal item
-        type FirstEditedState = <InitialState as TSEditItemInList<Op3Id, (Slot1,)>>::Result;
+        type FirstEditedState = <InitialState as TSEdit<Op3Id, (Slot1,)>>::Result;
         // println!("{}", std::any::type_name::<FirstEditedState>());
         // panic!();
         assert_eq!(
@@ -1072,26 +936,26 @@ mod tests {
             -1
         );
 
-        // // Ensure the state was edited correctly for mid-tuple item
-        // type EditedState = <InitialState as TSEditItemInList<Op2Id, (Slot3,)>>::Result;
+        // Ensure the state was edited correctly for mid-tuple item
+        type EditedState = <InitialState as TSEdit<Op2Id, (Slot3,)>>::Result;
         // println!("{}", std::any::type_name::<FirstEditedState>());
         // panic!();
-        // assert_eq!(
-        //     <<<<EditedState as TSSearch<Op2Id>>::Result as StateGetter>::State as TSSearch<
-        //         to_comp_id!(3),
-        //     >>::Result as IdGetter>::Id::to_u32(),
-        //     3
-        // );
-        // assert_eq!(
-        //     <<<<EditedState as TSSearch<Op2Id>>::Result as StateGetter>::State as TSSearch<
-        //         to_comp_id!(2),
-        //     >>::Result as IdGetter>::Id::to_i32(),
-        //     -1
-        // );
+        assert_eq!(
+            <<<<EditedState as TSSearch<Op2Id>>::Result as StateGetter>::State as TSSearch<
+                to_comp_id!(3),
+            >>::Result as IdGetter>::Id::to_u32(),
+            3
+        );
+        assert_eq!(
+            <<<<EditedState as TSSearch<Op2Id>>::Result as StateGetter>::State as TSSearch<
+                to_comp_id!(2),
+            >>::Result as IdGetter>::Id::to_i32(),
+            -1
+        );
 
         // Test that it works with a single item in a tuple
         type InitialState2 = (Op1,);
-        type EditedState2 = <InitialState2 as TSEditItemInList<Op1Id, (Slot3,)>>::Result;
+        type EditedState2 = <InitialState2 as TSEdit<Op1Id, (Slot3,)>>::Result;
         assert_eq!(
             <<<<EditedState2 as TSSearch<Op1Id>>::Result as StateGetter>::State as TSSearch<
                 to_comp_id!(3),
@@ -1101,22 +965,22 @@ mod tests {
     }
     #[test]
     fn test_ts_remove_operative() {
-        // type InitialState = (Op1, (Op2, (Op3, ())));
-        // type EditedState = <InitialState as TSRemoveItemFromList<Op3Id>>::Result;
-        // assert_eq!(
-        //     <<EditedState as TSSearch<Op3Id>>::Result as IdGetter>::Id::to_i32(),
-        //     -1
-        // );
-        // type EditedState2 = <EditedState as TSRemoveItemFromList<Op2Id>>::Result;
-        // assert_eq!(
-        //     <<EditedState2 as TSSearch<Op2Id>>::Result as IdGetter>::Id::to_i32(),
-        //     -1
-        // );
-        // type EditedState3 = <EditedState2 as TSRemoveItemFromList<Op3Id>>::Result;
-        // assert_eq!(
-        //     <<EditedState3 as TSSearch<Op3Id>>::Result as IdGetter>::Id::to_i32(),
-        //     -1
-        // );
+        type InitialState = (Op1, (Op2, (Op3,)));
+        type EditedState = <InitialState as TSRemove<Op3Id>>::Result;
+        assert_eq!(
+            <<EditedState as TSSearch<Op3Id>>::Result as IdGetter>::Id::to_i32(),
+            -1
+        );
+        type EditedState2 = <EditedState as TSRemove<Op2Id>>::Result;
+        assert_eq!(
+            <<EditedState2 as TSSearch<Op2Id>>::Result as IdGetter>::Id::to_i32(),
+            -1
+        );
+        type EditedState3 = <EditedState2 as TSRemove<Op3Id>>::Result;
+        assert_eq!(
+            <<EditedState3 as TSSearch<Op3Id>>::Result as IdGetter>::Id::to_i32(),
+            -1
+        );
     }
 }
 

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -4,282 +4,233 @@ use std::{
 };
 use typenum::*;
 
-// // Trait to represent the graph system's traits
-// trait GraphTrait {}
-
-// // Main builder struct
-// struct Builder<Fields, Slots> {
-//     _fields: PhantomData<Fields>,
-//     _slots: PhantomData<Slots>,
-// }
-
-// // Slot types with min and max
-
-// pub type Infinity = U1024;
 pub type NonExistent = P9;
 
 pub trait SlotTSMarker {
-    // const FULFILLS_UPPER_BOUND: bool;
-    // const FULFILLS_LOWER_BOUND: bool;
-    type Count: Integer + IsGreaterOrEqual<Self::Min> + IsLessOrEqual<Self::Max> + IsGreater<Z0>;
-    // + std::ops::Add<B1>
-    // + std::ops::Sub<B1>
-    // + typenum::Cmp<Self::Max>
-    // + typenum::Cmp<Self::Min>
-    // + typenum::Cmp<Z0>
-    // + typenum::private::IsEqualPrivate<
-    //     typenum::Z0,
-    //     <Self::Count as typenum::Cmp<typenum::Z0>>::Output,
-    // > + typenum::private::IsGreaterOrEqualPrivate<
-    //     Self::Min,
-    //     <Self::Count as typenum::Cmp<Self::Min>>::Output,
-    // > + typenum::private::IsLessOrEqualPrivate<
-    //     Self::Max,
-    //     <Self::Count as typenum::Cmp<Self::Max>>::Output,
-    // >;
-    type Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>;
-    type Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>;
-    type ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>;
-    // type IsFulfilled: Bit;
-    // type CanAddOne: Bit;
-    // type CanSubtractOne: Bit;
-    type MaxIsNonExistent: Bit;
-    type MinIsNonExistent: Bit;
     type CountIsGreaterThanOrEqualToMin: Bit;
     type CountIsGreaterThanZero: Bit;
     type CountIsLessThanOrEqualToMax: Bit;
 }
 pub struct SlotTS<
     Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
-    // + std::ops::Add<B1>
-    // + std::ops::Sub<B1>
-    // + typenum::Cmp<Max>
-    // + typenum::Cmp<Min>
-    // + typenum::Cmp<Z0>
-    // + typenum::private::IsEqualPrivate<typenum::Z0, <Count as typenum::Cmp<typenum::Z0>>::Output>
-    // + typenum::private::IsGreaterOrEqualPrivate<Min, <Count as typenum::Cmp<Min>>::Output>
-    // + typenum::private::IsLessOrEqualPrivate<Max, <Count as typenum::Cmp<Max>>::Output>,
-    Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>,
-    Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent> + typenum::Cmp<Count>,
-    ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>,
->(PhantomData<(Count, Min, Max, ZeroAllowed)>);
+    Min: Integer,
+    MinIsNonExistent: Bit,
+    Max: Integer,
+    MaxIsNonExistent: Bit,
+    ZeroAllowed: Bit,
+>(
+    PhantomData<(
+        Count,
+        Min,
+        MinIsNonExistent,
+        Max,
+        MaxIsNonExistent,
+        ZeroAllowed,
+    )>,
+);
 impl<
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
-        // + std::ops::Add<B1>
-        // + std::ops::Sub<B1>
-        // + typenum::Cmp<Max>
-        // + typenum::Cmp<Min>
-        // + typenum::Cmp<Z0>
-        // + typenum::private::IsEqualPrivate<
-        //     typenum::Z0,
-        //     <Count as typenum::Cmp<typenum::Z0>>::Output,
-        // > + typenum::private::IsGreaterOrEqualPrivate<Min, <Count as typenum::Cmp<Min>>::Output>
-        // + typenum::private::IsLessOrEqualPrivate<Max, <Count as typenum::Cmp<Max>>::Output>,
-        Min: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent>,
-        Max: Integer + Cmp<NonExistent> + typenum::IsEqual<NonExistent> + typenum::Cmp<Count>,
-        ZeroAllowed: Bit + IsEqual<B0> + IsEqual<B1>,
-    > SlotTSMarker for SlotTS<Count, Min, Max, ZeroAllowed>
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > SlotTSMarker for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
 {
-    type Count = Count;
-    type Min = Min;
-    type Max = Max;
-    type ZeroAllowed = ZeroAllowed;
-    // type IsFulfilled = op!(((Count <= Max) | (Max == NonExistent))
-    //     & ((Count >= Min) | ((Count == Z0) & (ZeroAllowed == B1)) | (Min == NonExistent)));
-    // type IsFulfilled = op!(((P1 <= P3) | (P3 == NonExistent))
-    //     & ((P1 >= P1) | ((P1 == Z0) & (ZeroAllowed == B1)) | (P1 == NonExistent)));
-    // const FULFILLS_UPPER_BOUND: bool = Count::I32 <= Max::I32 || Max::I32 == NonExistent::I32;
-    // const FULFILLS_LOWER_BOUND: bool = Count::I32 >= Min::I32
-    //     || (Count::I32 == 0 && ZeroAllowed::BOOL)
-    //     || Min::I32 == NonExistent::I32;
-    // type CountIsLessThanOrEqualToMax = <Count as IsLessOrEqual<Max>>::Output;
-    type MaxIsNonExistent = Eq<Max, NonExistent>;
-    type MinIsNonExistent = Eq<Max, NonExistent>;
     type CountIsGreaterThanOrEqualToMin = GrEq<Count, Min>;
     type CountIsLessThanOrEqualToMax = LeEq<Count, Max>;
     type CountIsGreaterThanZero = Gr<Count, Z0>;
-    // type MaxIsNonExistent = op!(Max == NonExistent);
-    // type IsFulfilled = <Self::CountIsLessThanOrEqualToMax as BitOr<Self::MaxIsNonExistent>>::Output; //Self::MaxIsNonExistent); // | (Max == NonExistent));
-    // type IsFulfilled = Or<Self::CountIsLessThanOrEqualToMax, Self::MaxIsNonExistent>;
-    // type CanAddOne = op!((Self::MaxIsNonExistent == B1) | (Count + B1 <= Max));
-    // type CanSubtractOne =
-    //     op!(Min == NonExistent | Count - B1 >= Min | (Count >= Z0 & ZeroAllowed == B1));
-
-    // const FULFILLS_UPPER_BOUND: bool = Count::I32 <= Max::I32 || Max::I32 == NonExistent::I32;
-    // const FULFILLS_LOWER_BOUND: bool = Count::I32 >= Min::I32
-    //     || (Count::I32 == 0 && ZeroAllowed::BOOL)
-    //     || Min::I32 == NonExistent::I32;
-    // pub const IS_FULFILLED: bool = Self::FULFILLS_UPPER_BOUND && Self::FULFILLS_LOWER_BOUND;
-    // pub const CAN_ADD_ONE: bool = if Max::I32 == NonExistent::I32 {
-    //     true
-    // } else {
-    //     Count::I32 + 1 <= Max::I32
-    // };
-    // /// Allow subtraction if subtracting one would leave the count within the min or if zero is allowed and the count is greater than zero
-    // pub const CAN_SUBTRACT_ONE: bool = if NonExistent::I32 == Min::I32 {
-    //     if Count::I32 == 0 {
-    //         false
-    //     } else {
-    //         true
-    //     }
-    // } else {
-    //     Count::I32 - 1 >= Min::I32 || (Count::I32 > 0 && ZeroAllowed::BOOL)
-    // };
 }
 
-// // Trait to modify a specific slot
-// trait ModifySlot<Name, Op> {
-//     type Output;
-// }
+pub trait CountIsLessThanOrEqualToMax {}
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > CountIsLessThanOrEqualToMax
+    for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+where
+    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+        SlotTSMarker<CountIsLessThanOrEqualToMax = B1>,
+{
+}
 
-// // Operation to increment a slot
-// struct Increment;
+pub trait WithinUpperBounds {}
+// If Max does not exist
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        // MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > WithinUpperBounds for SlotTS<Count, Min, MinIsNonExistent, Max, B1, ZeroAllowed>
+{
+}
+// If Max does exist and count is less than it
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        // MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > WithinUpperBounds for SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>
+where
+    SlotTS<Count, Min, MinIsNonExistent, Max, B0, ZeroAllowed>: CountIsLessThanOrEqualToMax,
+{
+}
 
-// // Operation to decrement a slot
-// struct Decrement;
+pub trait CountIsGreaterThanOrEqualToMin {}
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > CountIsGreaterThanOrEqualToMin
+    for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+where
+    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+        SlotTSMarker<CountIsGreaterThanOrEqualToMin = B1>,
+{
+}
 
-// // Implementation for Builder
-// impl<Fields, Slots> Builder<Fields, Slots> {
-//     fn new() -> Self {
-//         Builder {
-//             _fields: PhantomData,
-//             _slots: PhantomData,
-//         }
-//     }
-// }
+pub trait WithinLowerBounds {}
+// If Min exists and Count is greater than it
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        // MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > WithinLowerBounds for SlotTS<Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>
+where
+    SlotTS<Count, Min, B0, Max, MaxIsNonExistent, ZeroAllowed>: CountIsGreaterThanOrEqualToMin,
+{
+}
+// If Min does not exist
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        // MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > WithinLowerBounds for SlotTS<Count, Min, B1, Max, MaxIsNonExistent, ZeroAllowed>
+{
+}
 
-// // Implementation to modify a slot
-// impl<Fields, Name, Count, Min, Max, Traits, RestSlots, Op>
-//     Builder<Fields, (Slot<Name, Count, Min, Max, Traits>, RestSlots)>
-// where
-//     (Slot<Name, Count, Min, Max, Traits>, RestSlots): ModifySlot<Name, Op>,
-// {
-//     fn modify_slot(
-//         self,
-//     ) -> Builder<
-//         Fields,
-//         <(Slot<Name, Count, Min, Max, Traits>, RestSlots) as ModifySlot<Name, Op>>::Output,
-//     > {
-//         Builder {
-//             _fields: PhantomData,
-//             _slots: PhantomData,
-//         }
-//     }
-// }
+pub trait FulfilledSlotTS {}
+impl<
+        Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
+        Min: Integer,
+        MinIsNonExistent: Bit,
+        Max: Integer,
+        MaxIsNonExistent: Bit,
+        ZeroAllowed: Bit,
+    > FulfilledSlotTS for SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>
+where
+    SlotTS<Count, Min, MinIsNonExistent, Max, MaxIsNonExistent, ZeroAllowed>:
+        WithinLowerBounds + WithinUpperBounds,
+{
+}
 
-// // ModifySlot implementation for increment
-// impl<Name, Count, Min, Max, Traits, RestSlots> ModifySlot<Name, Increment>
-//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
-// where
-//     Count: Add<B1>,
-//     Max: Cmp<<Count as Add<B1>>::Output>,
-//     <Max as Cmp<<Count as Add<B1>>::Output>>::Output: IsGreaterOrEqual<B1>,
-// {
-//     type Output = (
-//         Slot<Name, <Count as Add<B1>>::Output, Min, Max, Traits>,
-//         RestSlots,
-//     );
-// }
+pub trait FulfilledSlotTupleTS {}
+impl<A> FulfilledSlotTupleTS for (A,) where A: FulfilledSlotTS {}
+impl<A, B> FulfilledSlotTupleTS for (A, B)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+{
+}
+impl<A, B, C> FulfilledSlotTupleTS for (A, B, C)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+{
+}
 
-// // ModifySlot implementation for decrement
-// impl<Name, Count, Min, Max, Traits, RestSlots> ModifySlot<Name, Decrement>
-//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
-// where
-//     Count: Sub<B1>,
-//     <Count as Sub<B1>>::Output: Cmp<Min>,
-//     <<Count as Sub<B1>>::Output as Cmp<Min>>::Output: IsGreaterOrEqual<B1>,
-// {
-//     type Output = (
-//         Slot<Name, <Count as Sub<B1>>::Output, Min, Max, Traits>,
-//         RestSlots,
-//     );
-// }
-
-// // Recursive case for ModifySlot
-// impl<Name, OtherName, OtherSlot, RestSlots, Op> ModifySlot<Name, Op> for (OtherSlot, RestSlots)
-// where
-//     RestSlots: ModifySlot<Name, Op>,
-// {
-//     type Output = (OtherSlot, <RestSlots as ModifySlot<Name, Op>>::Output);
-// }
-
-// // Trait to check if all slots are fulfilled
-// trait AllSlotsFulfilled {}
-
-// impl AllSlotsFulfilled for () {}
-
-// impl<Name, Count, Min, Max, Traits, RestSlots> AllSlotsFulfilled
-//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
-// where
-//     Count: Cmp<Min>,
-//     Max: Cmp<Count>,
-//     <Count as Cmp<Min>>::Output: IsGreaterOrEqual<B1>,
-//     <Max as Cmp<Count>>::Output: IsGreaterOrEqual<B1>,
-//     RestSlots: AllSlotsFulfilled,
-// {
-// }
-
-// // Build method
-// impl<Fields, Slots> Builder<Fields, Slots>
-// where
-//     Slots: AllSlotsFulfilled,
-// {
-//     fn build(self) -> String {
-//         "Built successfully".to_string()
-//     }
-// }
-
-// // Example usage
-// struct SlotA;
-// struct SlotB;
-
-// trait BuilderExt<Fields, Slots> {
-//     fn add_to_slot_a(self) -> Self;
-//     fn remove_from_slot_a(self) -> Self;
-//     fn add_to_slot_b(self) -> Self;
-//     fn remove_from_slot_b(self) -> Self;
-// }
-
-// impl<Fields, Slots> BuilderExt<Fields, Slots> for Builder<Fields, Slots>
-// where
-//     Slots: ModifySlot<SlotA, Increment>,
-//     Slots: ModifySlot<SlotA, Decrement>,
-//     Slots: ModifySlot<SlotB, Increment>,
-//     Slots: ModifySlot<SlotB, Decrement>,
-// {
-//     fn add_to_slot_a(self) -> Builder<Fields, <Slots as ModifySlot<SlotA, Increment>>::Output> {
-//         self.modify_slot::<SlotA, Increment>()
-//     }
-
-//     fn remove_from_slot_a(
-//         self,
-//     ) -> Builder<Fields, <Slots as ModifySlot<SlotA, Decrement>>::Output> {
-//         self.modify_slot::<SlotA, Decrement>()
-//     }
-
-//     fn add_to_slot_b(self) -> Builder<Fields, <Slots as ModifySlot<SlotB, Increment>>::Output> {
-//         self.modify_slot::<SlotB, Increment>()
-//     }
-
-//     fn remove_from_slot_b(
-//         self,
-//     ) -> Builder<Fields, <Slots as ModifySlot<SlotB, Decrement>>::Output> {
-//         self.modify_slot::<SlotB, Decrement>()
-//     }
-// }
-
-// fn main() {
-//     let builder = Builder::<(), (Slot<SlotA, U0, U1, U3, ()>, Slot<SlotB, U0, U1, U2, ()>)>::new();
-//     let builder = builder.add_to_slot_a().add_to_slot_b();
-//     let builder = builder.add_to_slot_a().remove_from_slot_b();
-//     // let builder = builder.add_to_slot_a(); // This would fail to compile if we try to add more than Max
-//     // let builder = builder.remove_from_slot_b(); // This would fail to compile if we try to remove below Min
-//     let result = builder.build();
-//     println!("{}", result);
-// }
-
-// // Example traits
-// struct Trait1;
-// struct Trait2;
-// impl GraphTrait for Trait1 {}
-// impl GraphTrait for Trait2 {}
+impl<A, B, C, D> FulfilledSlotTupleTS for (A, B, C, D)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E> FulfilledSlotTupleTS for (A, B, C, D, E)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E, F> FulfilledSlotTupleTS for (A, B, C, D, E, F)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+    F: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E, F, G> FulfilledSlotTupleTS for (A, B, C, D, E, F, G)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+    F: FulfilledSlotTS,
+    G: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E, F, G, H> FulfilledSlotTupleTS for (A, B, C, D, E, F, G, H)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+    F: FulfilledSlotTS,
+    G: FulfilledSlotTS,
+    H: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E, F, G, H, I> FulfilledSlotTupleTS for (A, B, C, D, E, F, G, H, I)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+    F: FulfilledSlotTS,
+    G: FulfilledSlotTS,
+    H: FulfilledSlotTS,
+    I: FulfilledSlotTS,
+{
+}
+impl<A, B, C, D, E, F, G, H, I, J> FulfilledSlotTupleTS for (A, B, C, D, E, F, G, H, I, J)
+where
+    A: FulfilledSlotTS,
+    B: FulfilledSlotTS,
+    C: FulfilledSlotTS,
+    D: FulfilledSlotTS,
+    E: FulfilledSlotTS,
+    F: FulfilledSlotTS,
+    G: FulfilledSlotTS,
+    H: FulfilledSlotTS,
+    I: FulfilledSlotTS,
+    J: FulfilledSlotTS,
+{
+}

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -1,8 +1,12 @@
 use std::{
+    any::TypeId,
+    fmt::Debug,
     marker::PhantomData,
-    ops::{Add, BitAnd, BitOr, Sub},
+    ops::{Add, BitAnd, BitOr, Not, Sub},
 };
 use typenum::*;
+
+use super::reactive::{EditRGSO, RBaseGraphEnvironment};
 
 pub type NonExistent = P9;
 
@@ -14,6 +18,7 @@ pub trait SlotTSMarker {
     type CountIsLessThanMax: Bit;
 }
 pub struct SlotTS<
+    // Id,
     Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
     Min: Integer,
     MinIsNonExistent: Bit,
@@ -22,6 +27,7 @@ pub struct SlotTS<
     ZeroAllowed: Bit,
 >(
     PhantomData<(
+        // Id,
         Count,
         Min,
         MinIsNonExistent,
@@ -135,7 +141,9 @@ impl<
 {
 }
 
-pub trait FulfilledSlotTS {}
+pub trait FulfilledSlotTS {
+    const IMPLEMENTED: bool = true;
+}
 impl<
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
         Min: Integer,
@@ -150,7 +158,9 @@ where
 {
 }
 
-pub trait SlotCanAddOne {}
+pub trait SlotCanAddOne {
+    const IMPLEMENTED: bool = true;
+}
 // If Max does not exist
 impl<
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
@@ -177,7 +187,9 @@ where
 {
 }
 
-pub trait SlotCanSubtractOne {}
+pub trait SlotCanSubtractOne {
+    const IMPLEMENTED: bool = true;
+}
 // If Min does not exist
 impl<
         Count: Integer + IsGreaterOrEqual<Min> + IsLessOrEqual<Max> + IsGreater<Z0>,
@@ -219,7 +231,9 @@ where
 {
 }
 
-pub trait FulfilledSlotTupleTS {}
+pub trait FulfilledSlotTupleTS {
+    const IMPLEMENTED: bool = true;
+}
 impl<A> FulfilledSlotTupleTS for (A,) where A: FulfilledSlotTS {}
 impl<A, B> FulfilledSlotTupleTS for (A, B)
 where
@@ -312,3 +326,372 @@ where
     J: FulfilledSlotTS,
 {
 }
+
+// ------------------------------------
+struct SlotId<const ID: u32>;
+
+pub struct OperativeTS<Id, State>(PhantomData<(Id, State)>);
+
+pub trait IdAndStateGetter {
+    type Id;
+    type State;
+}
+
+impl<Id, State> IdAndStateGetter for OperativeTS<Id, State> {
+    type Id = Id;
+    type State = State;
+}
+
+pub trait IfThenElse<Condition: Bit> {
+    type Output;
+}
+
+impl<T, F> IfThenElse<B1> for (T, F) {
+    type Output = T;
+}
+impl<T, F> IfThenElse<B0> for (T, F) {
+    type Output = F;
+}
+
+impl IdAndStateGetter for () {
+    type Id = N1;
+    type State = N1;
+}
+
+// --------------------------------------
+// FIND
+// --------------------------------------
+
+pub trait TSInnerSearch<Id, IsMatch> {
+    type Result;
+}
+
+impl<Id, T, Tail> TSInnerSearch<Id, B1> for (T, Tail)
+where
+    T: IdAndStateGetter,
+{
+    type Result = T;
+}
+
+impl<T, Id, Tail> TSInnerSearch<Id, B0> for (T, Tail)
+where
+    T: IdAndStateGetter,
+    Id: IsEqual<T::Id>,
+    Tail: TSInnerSearch<Id, Eq<Id, T::Id>>,
+{
+    type Result = Tail::Result;
+}
+impl<Id, T> TSInnerSearch<Id, B0> for T
+where
+    T: IdAndStateGetter,
+    Id: IsEqual<T::Id>,
+    (T, ()): IfThenElse<Eq<Id, T::Id>>,
+{
+    type Result = <(T, ()) as IfThenElse<Eq<Id, T::Id>>>::Output;
+}
+impl<Id, T> TSInnerSearch<Id, B1> for T
+where
+    T: IdAndStateGetter,
+    Id: IsEqual<T::Id>,
+    (T, ()): IfThenElse<Eq<Id, T::Id>>,
+{
+    type Result = <(T, ()) as IfThenElse<Eq<Id, T::Id>>>::Output;
+}
+
+pub trait TSSearch<Id> {
+    type Result;
+}
+
+impl<Id> TSSearch<Id> for () {
+    type Result = ();
+}
+impl<Id, First, Rest> TSSearch<Id> for (First, Rest)
+where
+    Id: IsEqual<First::Id>,
+    (First, Rest): TSInnerSearch<Id, Eq<Id, First::Id>>,
+    First: IdAndStateGetter,
+{
+    type Result = <(First, Rest) as TSInnerSearch<Id, Eq<Id, First::Id>>>::Result;
+}
+impl<Id, First> TSSearch<Id> for (First,)
+where
+    Id: IsEqual<First::Id>,
+    First: TSInnerSearch<Id, Eq<Id, First::Id>>,
+    First: IdAndStateGetter,
+{
+    type Result = <First as TSInnerSearch<Id, Eq<Id, First::Id>>>::Result;
+}
+
+// -----------------------------------------------
+// ADD
+// -----------------------------------------------
+
+pub trait TSAddOperative<T> {
+    type Result;
+}
+
+// impl<GTS, NewOperative> TSAddOperative<NewOperative> for (NewOperative, GTS)
+// where
+//     NewOperative: IdGetter,
+//     // GTS: Search<NewOperative::Id>,
+//     // <GTS as Search<NewOperative::Id>>::Result: IsEqual<B0>,
+// {
+//     type Result = (NewOperative, GTS);
+// }
+impl<GTS, NewOperative> TSAddOperative<NewOperative> for GTS
+where
+    NewOperative: IdAndStateGetter,
+    // GTS: Search<NewOperative::Id>,
+    // <GTS as Search<NewOperative::Id>>::Result: IsEqual<B0>,
+{
+    type Result = (NewOperative, GTS);
+}
+
+// ------------------------------------------
+// edit
+// ------------------------------------------
+
+pub trait TSEditOperative<Id, NewState> {
+    type Result;
+}
+
+impl<First, Rest, Id, NewState> TSEditOperative<Id, NewState> for (First, Rest)
+where
+    (First, Rest): TSSearch<Id>,
+    Id: IsEqual<First::Id>,
+    (First, Rest): ReplaceOperativeInTuple<Id, NewState, Eq<Id, First::Id>>,
+    <(First, Rest) as TSSearch<Id>>::Result: IdAndStateGetter<Id = Id>,
+    First: IdAndStateGetter,
+{
+    type Result =
+        <(First, Rest) as ReplaceOperativeInTuple<Id, NewState, Eq<Id, First::Id>>>::Result;
+}
+
+pub trait ReplaceOperativeInTuple<Id, NewState, IsMatch> {
+    type Result;
+}
+impl<Id, State, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B1>
+    for (OperativeTS<Id, State>, Rest)
+{
+    type Result = (OperativeTS<Id, NewState>, Rest);
+}
+
+impl<FirstId, FirstState, Id, NewState, Rest> ReplaceOperativeInTuple<Id, NewState, B0>
+    for (OperativeTS<FirstId, FirstState>, Rest)
+where
+    Id: IsEqual<FirstId>,
+    Rest: ReplaceOperativeInTuple<Id, NewState, Eq<Id, FirstId>>,
+{
+    type Result = (
+        OperativeTS<FirstId, FirstState>,
+        <Rest as ReplaceOperativeInTuple<Id, NewState, Eq<Id, FirstId>>>::Result,
+    );
+}
+
+// ---------------------------------------------------
+// REMOVE
+// ---------------------------------------------------
+
+pub trait TSRemoveOperative<T> {
+    type Result;
+}
+
+impl<First, Rest, Id> TSRemoveOperative<Id> for (First, Rest)
+where
+    (First, Rest): TSSearch<Id>,
+    <(First, Rest) as TSSearch<Id>>::Result: IdAndStateGetter<Id = Id>,
+    First: IdAndStateGetter,
+    Id: IsEqual<First::Id>,
+    (First, Rest): RemoveOperativeFromTuple<Id, Eq<Id, First::Id>>,
+{
+    type Result = <(First, Rest) as RemoveOperativeFromTuple<Id, Eq<Id, First::Id>>>::Result;
+}
+
+pub trait RemoveOperativeFromTuple<Id, IsMatch> {
+    type Result;
+}
+
+impl<Id, State, Rest> RemoveOperativeFromTuple<Id, B1> for (OperativeTS<Id, State>, Rest) {
+    type Result = Rest;
+}
+
+impl<FirstId, FirstState, Id, Rest> RemoveOperativeFromTuple<Id, B0>
+    for (OperativeTS<FirstId, FirstState>, Rest)
+where
+    Id: Same<FirstId>,
+    Rest: RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>,
+{
+    type Result = (
+        OperativeTS<FirstId, FirstState>,
+        <Rest as RemoveOperativeFromTuple<Id, <Id as Same<FirstId>>::Output>>::Result,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::post_generation::reactive::RGSO;
+
+    use super::*;
+    use typenum::*;
+
+    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
+    type Slot2 = SlotTS<P2, P1, B0, P3, B0, B0>;
+    type Slot3 = SlotTS<P3, P1, B0, P5, B0, B1>;
+    type Op1 = OperativeTS<P1, (Slot1,)>;
+    type Op2 = OperativeTS<P2, (Slot2,)>;
+    type Op3 = OperativeTS<P3, (Slot3, Slot1)>;
+
+    #[test]
+    fn test_search() {
+        assert_eq!(
+            <<(Op1, Op2) as TSSearch<P1>>::Result as IdAndStateGetter>::Id::to_i32(),
+            1
+        );
+        assert_eq!(
+            <<(Op1, Op2) as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
+            2
+        );
+
+        let result = <<() as TSSearch<U1>>::Result as IdAndStateGetter>::Id::to_i32();
+        assert_eq!(result, -1);
+
+        // Test searching in a single-element tuple
+        assert_eq!(
+            <<(Op1,) as TSSearch<P1>>::Result as IdAndStateGetter>::Id::to_i32(),
+            1
+        );
+    }
+    #[test]
+    fn test_fulfilled_slot_ts() {
+        // Valid slots
+        assert_eq!(<Slot1 as FulfilledSlotTS>::IMPLEMENTED, true);
+        assert_eq!(<Slot2 as FulfilledSlotTS>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_fulfilled_slot_tuple_ts() {
+        // Valid tuples
+        assert_eq!(<(Slot1,) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+        assert_eq!(<(Slot1, Slot2) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+
+        assert_eq!(
+            <(Slot1, Slot2, Slot3) as FulfilledSlotTupleTS>::IMPLEMENTED,
+            true
+        );
+    }
+
+    #[test]
+    fn test_slot_can_add_one() {
+        // Can add one
+        assert_eq!(<Slot1 as SlotCanAddOne>::IMPLEMENTED, true);
+
+        // Cannot add one (at max)
+        type SlotAtMax = SlotTS<P3, Z0, B1, P3, B0, B0>;
+        // Uncomment to verify compilation error
+        // assert_eq!(<SlotAtMax as SlotCanAddOne>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_slot_can_subtract_one() {
+        // Can subtract one
+        assert_eq!(<Slot2 as SlotCanSubtractOne>::IMPLEMENTED, true);
+
+        // Cannot subtract one (at min)
+        type SlotAtMin = SlotTS<P1, P1, B0, P3, B0, B0>;
+        // Uncomment to verify compilation error
+        // assert_eq!(<SlotAtMin as SlotCanSubtractOne>::IMPLEMENTED, true);
+    }
+
+    #[test]
+    fn test_ts_add_operative() {
+        type InitialState = (Op1,);
+        type NewState = <InitialState as TSAddOperative<Op2>>::Result;
+
+        // Ensure the new state includes Op1
+        assert_eq!(
+            <<NewState as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
+            2
+        );
+
+        type NewState2 = <InitialState as TSAddOperative<Op3>>::Result;
+        assert_eq!(
+            <<NewState2 as TSSearch<P3>>::Result as IdAndStateGetter>::Id::to_i32(),
+            3
+        );
+        // Adding the same operative again should not compile
+        // Uncomment to verify compilation error
+        // type InvalidState = <NewState as TSAddOperative<Op1>>::Result;
+    }
+
+    // #[test]
+    // fn test_ts_edit_operative() {
+    //     type InitialState = (Op1, Op2);
+    //     type NewOp1 = OperativeTS<P1, (P2,)>;
+    //     // type NewOp2 = OperativeTS<P1, (P1,)>;
+    //     type EditedState = <InitialState as TSEditOperative<P1, (P3,)>>::Result;
+
+    //     // Ensure the state was edited correctly
+    //     assert_eq!(
+    //         <<EditedState as TSSearch<P1>>::Result as SlotTSMarker>::CountIsLessThanMax::to_bool(),
+    //         false
+    //     );
+    //     // You might need to add more specific checks here to ensure the state was updated correctly
+    // }
+
+    // #[test]
+    // fn test_ts_remove_operative() {
+    //     type InitialState = RBaseGraphEnvironmentWithTypestate<DummySchema, (Op1, Op2)>;
+    //     type RemovedState = <InitialState as TSRemoveOperative<P1>>::Result;
+
+    //     // Ensure Op1 was removed
+    //     // This should not compile if Op1 was successfully removed
+    //     // Uncomment to verify compilation error
+    //     // let _result = <<RemovedState as Search<P1>>::Result as IdGetter>::Id::to_i32();
+
+    //     // Ensure Op2 is still present
+    //     assert_eq!(
+    //         <<RemovedState as TSSearch<P2>>::Result as IdAndStateGetter>::Id::to_i32(),
+    //         2
+    //     );
+    // }
+}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    fn test() {
+///        type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
+///        assert_eq!(<InvalidSlot as FulfilledSlotTS>::IMPLEMENTED, true);
+///    }
+/// ```
+fn test_unfulfilled_slot() {}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
+///    fn test() {
+///         type InvalidSlot = SlotTS<P4, Z0, B1, P3, B0, B0>;
+///         assert_eq!(<(Slot1, InvalidSlot) as FulfilledSlotTupleTS>::IMPLEMENTED, true);
+///    }
+/// ```
+fn test_unfulfilled_slot_tuple() {}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+/// ```compile_fail
+///    use typenum::*;
+///    use base_types::post_generation::type_level::*;
+///    type Slot1 = SlotTS<P1, Z0, B1, P3, B0, B0>;
+///    type Slot2 = SlotTS<P2, P1, B0, P3, B0, B0>;
+///    type Op1 = OperativeTS<P1, (Slot1,)>;
+///    type Op2 = OperativeTS<P2, (Slot2,)>;
+///    fn test() {
+///         let _result = <<(Op1, Op2) as Search<U3>>::Result as IdGetter>::Id::to_i32();
+///    }
+/// ```
+fn test_failed_search() {}

--- a/base_types/src/post_generation/type_level.rs
+++ b/base_types/src/post_generation/type_level.rs
@@ -1,0 +1,174 @@
+// use std::{
+//     marker::PhantomData,
+//     ops::{Add, Sub},
+// };
+// use typenum::*;
+
+// // Trait to represent the graph system's traits
+// trait GraphTrait {}
+
+// // Main builder struct
+// struct Builder<Fields, Slots> {
+//     _fields: PhantomData<Fields>,
+//     _slots: PhantomData<Slots>,
+// }
+
+// // Slot types with min and max
+// struct Slot<Name, Count, Min, Max, Traits>(PhantomData<(Name, Count, Min, Max, Traits)>);
+
+// // Trait to modify a specific slot
+// trait ModifySlot<Name, Op> {
+//     type Output;
+// }
+
+// // Operation to increment a slot
+// struct Increment;
+
+// // Operation to decrement a slot
+// struct Decrement;
+
+// // Implementation for Builder
+// impl<Fields, Slots> Builder<Fields, Slots> {
+//     fn new() -> Self {
+//         Builder {
+//             _fields: PhantomData,
+//             _slots: PhantomData,
+//         }
+//     }
+// }
+
+// // Implementation to modify a slot
+// impl<Fields, Name, Count, Min, Max, Traits, RestSlots, Op>
+//     Builder<Fields, (Slot<Name, Count, Min, Max, Traits>, RestSlots)>
+// where
+//     (Slot<Name, Count, Min, Max, Traits>, RestSlots): ModifySlot<Name, Op>,
+// {
+//     fn modify_slot(
+//         self,
+//     ) -> Builder<
+//         Fields,
+//         <(Slot<Name, Count, Min, Max, Traits>, RestSlots) as ModifySlot<Name, Op>>::Output,
+//     > {
+//         Builder {
+//             _fields: PhantomData,
+//             _slots: PhantomData,
+//         }
+//     }
+// }
+
+// // ModifySlot implementation for increment
+// impl<Name, Count, Min, Max, Traits, RestSlots> ModifySlot<Name, Increment>
+//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
+// where
+//     Count: Add<B1>,
+//     Max: Cmp<<Count as Add<B1>>::Output>,
+//     <Max as Cmp<<Count as Add<B1>>::Output>>::Output: IsGreaterOrEqual<B1>,
+// {
+//     type Output = (
+//         Slot<Name, <Count as Add<B1>>::Output, Min, Max, Traits>,
+//         RestSlots,
+//     );
+// }
+
+// // ModifySlot implementation for decrement
+// impl<Name, Count, Min, Max, Traits, RestSlots> ModifySlot<Name, Decrement>
+//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
+// where
+//     Count: Sub<B1>,
+//     <Count as Sub<B1>>::Output: Cmp<Min>,
+//     <<Count as Sub<B1>>::Output as Cmp<Min>>::Output: IsGreaterOrEqual<B1>,
+// {
+//     type Output = (
+//         Slot<Name, <Count as Sub<B1>>::Output, Min, Max, Traits>,
+//         RestSlots,
+//     );
+// }
+
+// // Recursive case for ModifySlot
+// impl<Name, OtherName, OtherSlot, RestSlots, Op> ModifySlot<Name, Op> for (OtherSlot, RestSlots)
+// where
+//     RestSlots: ModifySlot<Name, Op>,
+// {
+//     type Output = (OtherSlot, <RestSlots as ModifySlot<Name, Op>>::Output);
+// }
+
+// // Trait to check if all slots are fulfilled
+// trait AllSlotsFulfilled {}
+
+// impl AllSlotsFulfilled for () {}
+
+// impl<Name, Count, Min, Max, Traits, RestSlots> AllSlotsFulfilled
+//     for (Slot<Name, Count, Min, Max, Traits>, RestSlots)
+// where
+//     Count: Cmp<Min>,
+//     Max: Cmp<Count>,
+//     <Count as Cmp<Min>>::Output: IsGreaterOrEqual<B1>,
+//     <Max as Cmp<Count>>::Output: IsGreaterOrEqual<B1>,
+//     RestSlots: AllSlotsFulfilled,
+// {
+// }
+
+// // Build method
+// impl<Fields, Slots> Builder<Fields, Slots>
+// where
+//     Slots: AllSlotsFulfilled,
+// {
+//     fn build(self) -> String {
+//         "Built successfully".to_string()
+//     }
+// }
+
+// // Example usage
+// struct SlotA;
+// struct SlotB;
+
+// trait BuilderExt<Fields, Slots> {
+//     fn add_to_slot_a(self) -> Self;
+//     fn remove_from_slot_a(self) -> Self;
+//     fn add_to_slot_b(self) -> Self;
+//     fn remove_from_slot_b(self) -> Self;
+// }
+
+// impl<Fields, Slots> BuilderExt<Fields, Slots> for Builder<Fields, Slots>
+// where
+//     Slots: ModifySlot<SlotA, Increment>,
+//     Slots: ModifySlot<SlotA, Decrement>,
+//     Slots: ModifySlot<SlotB, Increment>,
+//     Slots: ModifySlot<SlotB, Decrement>,
+// {
+//     fn add_to_slot_a(self) -> Builder<Fields, <Slots as ModifySlot<SlotA, Increment>>::Output> {
+//         self.modify_slot::<SlotA, Increment>()
+//     }
+
+//     fn remove_from_slot_a(
+//         self,
+//     ) -> Builder<Fields, <Slots as ModifySlot<SlotA, Decrement>>::Output> {
+//         self.modify_slot::<SlotA, Decrement>()
+//     }
+
+//     fn add_to_slot_b(self) -> Builder<Fields, <Slots as ModifySlot<SlotB, Increment>>::Output> {
+//         self.modify_slot::<SlotB, Increment>()
+//     }
+
+//     fn remove_from_slot_b(
+//         self,
+//     ) -> Builder<Fields, <Slots as ModifySlot<SlotB, Decrement>>::Output> {
+//         self.modify_slot::<SlotB, Decrement>()
+//     }
+// }
+
+// fn main() {
+//     let builder = Builder::<(), (Slot<SlotA, U0, U1, U3, ()>, Slot<SlotB, U0, U1, U2, ()>)>::new();
+//     let builder = builder.add_to_slot_a().add_to_slot_b();
+//     let builder = builder.add_to_slot_a().remove_from_slot_b();
+//     // let builder = builder.add_to_slot_a(); // This would fail to compile if we try to add more than Max
+//     // let builder = builder.remove_from_slot_b(); // This would fail to compile if we try to remove below Min
+//     let result = builder.build();
+//     println!("{}", result);
+// }
+
+// // Example traits
+// struct Trait1;
+// struct Trait2;
+// impl GraphTrait for Trait1 {}
+// impl GraphTrait for Trait2 {}

--- a/devlog.md
+++ b/devlog.md
@@ -421,8 +421,8 @@ I am thinking through the editing story and where to store the necessary typesta
 Right now there are two entry points:
 - Calling OperativeName::new()
 - Calling ExistingOperative::edit()
-Both of these entry points return a MainBuilder which represents some subgraph (or potentially multiple disconnected subgraphs if MainBuilders are combined with `integrate`)
-Once the user has a MainBuilder, they have 3 choices for filling a given slot:
+Both of these entry points return a FreshBuilder which represents some subgraph (or potentially multiple disconnected subgraphs if MainBuilders are combined with `integrate`)
+Once the user has a FreshBuilder, they have 3 choices for filling a given slot:
 - add_new_{slot_name}_{slotted_operative_name}
 - add_existing_or_temp_{slot_name}_{slotted_operative_name}
 - add_and_edit_existing_{slot_name}_{slotted_operative_name}
@@ -437,7 +437,7 @@ With this typestate rewrite, though, it became convenient to enumerate that type
 
 One of the main questions is regarding how to handle referencing existing nodes to add to a slot (or to edit).
 Currently there is a lot of runtime checking done to ensure that the id passed into one of these methods points to a valid item for the operation in question.
-This wasn't too big of a deal earlier since I was already doing a bunch of runtime checking to ensure that all of the operations in a final MainBuilder adhered to the schema.
+This wasn't too big of a deal earlier since I was already doing a bunch of runtime checking to ensure that all of the operations in a final FreshBuilder adhered to the schema.
 But now, I think a lot of this checking is redundant with these typestate guards. The typestate should (in theory) make it impossible for a user to misconfigure any action.
 The only remaining runtime check which seems to be necessary is that of referencing an existing node (or a temporary node, which is also a fallible action if the user did not create a temporary node of the same name that they are subsequently looking up).
 It seems to me this should be done explicitly immediately upon calling a method which requires an existing node, and that method should return a Result.

--- a/devlog.md
+++ b/devlog.md
@@ -63,7 +63,7 @@ How can you instantiate a schema element during the process of creating the sche
 Trying now to ascertain what exactly will need to happen in the macro, and what the interface will be between pre-macro types (building the schema with ConstraintObjects) and post-macro types.
 It seems like the libraries will need to exist in both places (Instance library & Operative library). For the pre-macro work, you'll need to define templates in terms of instances and operatives, so you'll need to be keeping a running library. For post-macro work, you'll need to reference the library if you want to get information about the structure of a given template.
 
-I'm not certain it makes sense to think of pre-macro work -- maybe it will be intra-macro work. 
+I'm not certain it makes sense to think of pre-macro work -- maybe it will be intra-macro work.
 The issue I'm grappling with is aligning the input and output of the macro in a way where things work out nicely.
 
 ### Brief Overview of Schema Elements
@@ -121,12 +121,12 @@ Part 2 will be describing how a constraint object fulfills a trait. This is some
   This gets a little fuzzy when it comes to how you'd compose a larger type from smaller constituent parts.
   Say method A_a is required to return type Bar {name: String, id: u32}, and you want to get the name from one location in the structure and the id from another.
   Not sure yet how this might work.
-Part 3 is actually creating a method from the description provided in step 2. 
+Part 3 is actually creating a method from the description provided in step 2.
   When translating from a constraint object to a SchemaObject, the locations provided need to be translated into a method which reaches out to those locations and returns the values.
 
 This trait system would give a depth to composibility which wouldn't be present in a simple label system which I had been considering before.
     function: Fn<u32> -> u32,
-Whether traits or labels, it seems clear that some kind of type-like system is required in order to be able to denote which constructs are allowed to be slotted into a template's dependencies. For simple systems or ones in which you are ok relying on non-deterministic interpretation, not having any types would be ok. However, it quickly becomes apparent that it would be helpful to restrict or type the possible inputs. You could imagine a "performs_action" template where you'd want to restrict one slot to "Entity" and one slot to "Action". Without a system which allows for differentiation, you would be unable to do so but would instead have to accept any construct in any slot. 
+Whether traits or labels, it seems clear that some kind of type-like system is required in order to be able to denote which constructs are allowed to be slotted into a template's dependencies. For simple systems or ones in which you are ok relying on non-deterministic interpretation, not having any types would be ok. However, it quickly becomes apparent that it would be helpful to restrict or type the possible inputs. You could imagine a "performs_action" template where you'd want to restrict one slot to "Entity" and one slot to "Action". Without a system which allows for differentiation, you would be unable to do so but would instead have to accept any construct in any slot.
 The trait system gives a natural kind of inheritance structure, where if a constituent component implements a particular trait and the encompassing template wants to also expose that trait on itself, it should just be able to point to the implementation in the constituent.
 
 It feels more and more like I'm re-implementing Rust inside of Rust. Not quite to that level, but I need to expose some of the powerful compositional patterns.
@@ -139,7 +139,7 @@ This will need to be known at the time of parsing the ConstraintSchema from JSON
 Should there be separate JSON files for each which are parsed first into concrete enums, then they could be present for the parsing of the ConstraintSchema?
 
 ## Jan 23, 2024
-In the process of making a macro which transforms a ConstraintSchema into a concrete schema for use. Encountering questions like: should things like the reactive system be implemented at this stage in the structure of a ConcreteSchema? For example, you could make the fields and edges of a given template be signals. 
+In the process of making a macro which transforms a ConstraintSchema into a concrete schema for use. Encountering questions like: should things like the reactive system be implemented at this stage in the structure of a ConcreteSchema? For example, you could make the fields and edges of a given template be signals.
 Are there ever cases where the step I'm describing (transforming a ConstraintSchema into a usable state) would be desired without including reactive functionality?
 I guess I should disambiguate "usable state". By this, I mean several things:
 1. The process of creating concrete data structures from the ConstraintSchema -- useful for representing graphs built in schemaful environments
@@ -147,7 +147,7 @@ I guess I should disambiguate "usable state". By this, I mean several things:
 The instantiation and editing methods are where the signals come in handy -- but they require that the data structure be constructed out of signals to support this functionality.
   I could foresee environments which want to be read-only and would not make use of the signal architecture. This doesn't seem too pressing, though -- you'd have all of the same functionality with the signal structure, it would just be a question of performance impact. If this becomes an issue then it ought to be relatively simple to make another, non-reactive representation of the data structures to be used in such contexts.
 
-Current complexity: How to represent and handle operative nodes and edges in templates. 
+Current complexity: How to represent and handle operative nodes and edges in templates.
 
 
 ## Jan 24, 2024
@@ -205,12 +205,12 @@ I think that it's probably good to keep this goal of interoperability in mind, b
 ## Jan 29, 2024
 Trying to think of alternative ways to build the schema types without relying on a reference to some kind of graph environment.
 Several places seem like they'd require this:
-- Resolving trait implementations which rely on data resolved in constituents. 
+- Resolving trait implementations which rely on data resolved in constituents.
   I.e. there may be constituents which will need to be initialized before they have the requisite data, so to write a method for the trait implementation, there will need to be some way to retrieve that instantiated constituent.
   E.g. Struct1 is implementing Trait1, which has a method Method1 which returns a u32. Struct1 has an operative constituent Struct2 which has a field "my_num". There's no way at compile time to reference this my_num field directly from Struct1 -- the operative structure of Struct2 has the knowledge of what that field *will* hold, but it will never be filled until it has been instantiated, at which point it is living in the graph environment and not in the schema.
 - Instantiation -- whether of a particular ConstraintObject or of the requisite constituent elements required to instantiate that ConstraintObject.
 
-Also grappling with the related question of how to create the final types in a relatively agnostic way, or if that is required. In other words, it seems like it might be helpful to build the types in terms of Signals directly from the macro. I'm not really sure what the alternative would be, other than making a parallel Signaled type and providing some kind of Into<> implementation. 
+Also grappling with the related question of how to create the final types in a relatively agnostic way, or if that is required. In other words, it seems like it might be helpful to build the types in terms of Signals directly from the macro. I'm not really sure what the alternative would be, other than making a parallel Signaled type and providing some kind of Into<> implementation.
 I just get worried about making the schema macro and the graph environment too coupled. Maybe I shouldn't be, though, as long as the ConstraintSchema remains agnostic.
 
 This feels like it's pushing at the edges of the bigger project picture and I don't know that I have the right answers right now. I might just make a prototype to get something working at a basic level, but I hope to get some insights that make these questions feel like they fit better in to the great whole eventually.
@@ -240,7 +240,7 @@ Trying to wrap my head around useful next steps. At a relatively stable place co
 The next big question is regarding how useful it would be to continue with the previous path of creating a macro to generate one large schema enum with methods for instantiation and things.
 Under what circumstances would such a thing be useful? What capabilities ought it to have to be most useful?
 Maybe taking a step back and away from the macro to consider the goals that are trying to be reached.
-The schema creator allows a user to explicitly define a set of rules about what structures are allowed and how they are allowed to interact. It lays the foundation for an environment in which graph constructs can be instantiated according to the rules. 
+The schema creator allows a user to explicitly define a set of rules about what structures are allowed and how they are allowed to interact. It lays the foundation for an environment in which graph constructs can be instantiated according to the rules.
 The next piece of the ecosystem is regarding how that environment will function. We have the foundation (the schema which defines the rules), but the environment is as of yet undefined.
 There needs to be a way to instantiate and connect graph constructs according to the schema.
 To what end?
@@ -316,7 +316,7 @@ With the addition of operative slots having variable numbers of elements, there 
 Previously, you could select a field or trait impl of some constituent operative and be sure that there would be exactly 1 instance from which to extract the information required.
 
 Longer term, it seems like it would be very valuable to be able to express some kind of map or filter operation on the elements of a given operative slot.
-But this would require creating a whole syntax for mapping over the structure -- some way to: 
+But this would require creating a whole syntax for mapping over the structure -- some way to:
 1. express the operations which would be performed on the elements,
 2. perform arithmetic to combine or otherwise manipulate the results of the operations,
 3. massage the results into the correct shape to fulfill the expected trait contract.
@@ -400,4 +400,16 @@ So there's not really any way to generalize over all of the methods even though 
 It might be possible to look into providing a subset of those methods (for example, all of the get-related ones) on the resultant enum.
 But in order to make any changes you'd need to do a deep match.
 
-Once again, though, I think that that pattern is antipattern. The idea should be to build in a composable fashion. The details of how to do that in this case escape me at the present. 
+Once again, though, I think that that pattern is antipattern. The idea should be to build in a composable fashion. The details of how to do that in this case escape me at the present.
+
+## July 24, 2024
+It seems like it should be possible to check the validity of graph structures at compile time.
+I'd like to think through the necessary typestate which could achieve this goal.
+High level goals:
+- Only expose methods for adding fulfilling elements to fields or slots when these are valid actions (i.e. don't allow the user to call "add_element_to_slot" if that slot's capacity is full)
+- Similarly, only expose methods for removing from a slot or field when that is a valid action.
+- Only allow the user to build/finalize the structure if all fields and slots are in a satisfied state
+
+Currently, it seems like there is only one conceptual bottleneck in making the graph-construction process entirely compile-time safe: adding an existing element to a slot.
+At this moment, I'm having a difficult time seeing how to perform the necessary check to see if the element is the correct type. Right now, this interface
+just accepts an ID and performs the check at runtime. Perhaps it would be possible to alter the interface.

--- a/generate_schema_reactive/Cargo.toml
+++ b/generate_schema_reactive/Cargo.toml
@@ -20,7 +20,7 @@ features = [
 [dependencies]
 base_types = { path = "../base_types", features = [
     "to_tokens",
-    "reactive",
+    # "reactive",
 ] } # molecule_schema = { path = "../molecule_schema" }
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"

--- a/generate_schema_reactive/Cargo.toml
+++ b/generate_schema_reactive/Cargo.toml
@@ -31,3 +31,4 @@ reactive_types = { path = "../reactive_types" }
 # anyhow = "1.0"
 lazy_static = "1.4"
 leptos = { version = "0.6", features = ["csr"] }
+typenum = "1"

--- a/generate_schema_reactive/Cargo.toml
+++ b/generate_schema_reactive/Cargo.toml
@@ -18,6 +18,7 @@ features = [
 ]
 
 [dependencies]
+to_composite_id_macro = {path = "../to_composite_id_macro"}
 base_types = { path = "../base_types", features = [
     "to_tokens",
     # "reactive",

--- a/generate_schema_reactive/src/generate_operative_streams.rs
+++ b/generate_schema_reactive/src/generate_operative_streams.rs
@@ -123,7 +123,7 @@ pub(crate) fn generate_operative_streams(
         quote! {None}
     } else {
         quote! {
-            Some(std::collections::HashMap::from([#((#active_slot_ids, #active_slots),)*]))
+            Some(std::collections::BTreeMap::from([#((#active_slot_ids, #active_slots),)*]))
         }
     };
 
@@ -379,10 +379,6 @@ pub(crate) fn generate_operative_streams(
         //     ),
         //     Span::call_site(),
         // );
-        let remove_from_slot_fn_name = Ident::new(
-            &format!("remove_from_{}", slot.slot.tag.name.to_lowercase()),
-            Span::call_site(),
-        );
         let local_count_generic = Ident::new(&format!("TCount{}", slot_name), Span::call_site());
         let (
             local_min,
@@ -863,6 +859,10 @@ pub(crate) fn generate_operative_streams(
                 }
             }
         };
+        let remove_from_slot_fn_name = Ident::new(
+            &format!("remove_from_{}", slot.slot.tag.name.to_lowercase()),
+            Span::call_site(),
+        );
         let remove_slot_trait_name = Ident::new(&format!("RemoveFromSlot{}{}", slot_name, struct_name), Span::call_site());
         quote! {
             // pub trait #remove_slot_trait_name {
@@ -934,11 +934,11 @@ pub(crate) fn generate_operative_streams(
 
         pub trait #edit_rgso_trait_name<FieldsTS, SlotsTS> {
             // TODO: Placeholder ()s
-            fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, ()> ;
+            fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, SlotsTS> ;
         }
         impl<FieldsTS, SlotsTS> #edit_rgso_trait_name<FieldsTS, SlotsTS> for RGSOConcrete<#struct_name, Schema> {
             // TODO: Placeholder ()s
-            fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, ()> {
+            fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, SlotsTS> {
                 MainBuilder {
                     inner_builder: #struct_name::initiate_edit(*self.get_id(), graph.into()),
                     _fields_typestate: std::marker::PhantomData,

--- a/generate_schema_reactive/src/generate_operative_streams.rs
+++ b/generate_schema_reactive/src/generate_operative_streams.rs
@@ -720,7 +720,7 @@ pub(crate) fn generate_operative_streams(
         impl RBuildable for #struct_name {
             type Schema = Schema;
 
-            fn initiate_build(graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Self::Schema>>>) -> RGSOBuilder<#struct_name, Schema> {
+            fn initiate_build(graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Self::Schema>>>) -> SubgraphBuilder<#struct_name, Schema> {
                 let template_ref = CONSTRAINT_SCHEMA.template_library.get(&#reference_template_id).unwrap();
                 let operative_ref = CONSTRAINT_SCHEMA.operative_library.get(&#operative_id).unwrap();
                 #[allow(unused_mut)]
@@ -735,15 +735,15 @@ pub(crate) fn generate_operative_streams(
                             graph.clone(),
                             );
                 let id = wrapper_builder.get_id().clone();
-                RGSOBuilder::<#struct_name, Schema>::new(
+                SubgraphBuilder::<#struct_name, Schema>::new(
                         Some(wrapper_builder),
                         id,
                         graph,
                     )
             }
-            fn initiate_edit(id: base_types::common::Uid, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Self::Schema>>>) -> RGSOBuilder<#struct_name, Schema> {
+            fn initiate_edit(id: base_types::common::Uid, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Self::Schema>>>) -> SubgraphBuilder<#struct_name, Schema> {
                 let graph: std::rc::Rc<RBaseGraphEnvironment<Self::Schema>> = graph.into();
-                RGSOBuilder::<#struct_name, Schema>::new(
+                SubgraphBuilder::<#struct_name, Schema>::new(
                         None,
                             id,
                         graph,

--- a/generate_schema_reactive/src/generate_operative_streams.rs
+++ b/generate_schema_reactive/src/generate_operative_streams.rs
@@ -774,7 +774,7 @@ pub(crate) fn generate_operative_streams(
                     + Cmp<#local_min>
                     + Cmp<#local_max>
                     + Cmp<PInt<UInt<UTerm, B1>>>,
-                    // where Or<#slot_generic_in_question::MaxIsNonExistent, op!((#slot_generic_in_question::Count + B1) <= Max) = typenum::B1>
+                    base_types::post_generation::type_level::SlotTS<#local_count_generic,#slot_ts_consts_stream >: base_types::post_generation::type_level::SlotCanAddOne
                 {
                     #add_new_fn_definitions
                     pub #add_existing_and_edit_fn_signature
@@ -881,7 +881,7 @@ pub(crate) fn generate_operative_streams(
             + Cmp<#local_min>
             + Cmp<#local_max>
             + Cmp<PInt<UInt<UTerm, B1>>>,
-                // where #slot_generic_in_question::<CanSubtractOne = typenum::B1>
+            base_types::post_generation::type_level::SlotTS<#local_count_generic,#slot_ts_consts_stream >: base_types::post_generation::type_level::SlotCanSubtractOne
             {
                 pub fn #remove_from_slot_fn_name(mut self, target_id: &Uid) -> #return_type_after_subtracting {
                     self.inner_builder.remove_outgoing(base_types::post_generation::SlotRef{

--- a/generate_schema_reactive/src/generate_operative_streams.rs
+++ b/generate_schema_reactive/src/generate_operative_streams.rs
@@ -191,7 +191,7 @@ pub(crate) fn generate_operative_streams(
             pub trait field_getting_manipulate_field_trait_name {
                 fn #field_getter_fn_name(&self) -> #field_value_type;
             }
-            impl #field_getting_manipulate_field_trait_name for RGSOWrapper<#struct_name, Schema> {
+            impl #field_getting_manipulate_field_trait_name for RGSOConcrete<#struct_name, Schema> {
                 fn #field_getter_fn_name(&self) -> #field_value_type {
                     #locked_return_val
                 }
@@ -677,7 +677,7 @@ pub(crate) fn generate_operative_streams(
     let trait_impl_streams =
         generate_trait_impl_streams::generate_trait_impl_streams(&instantiable, constraint_schema);
     let edit_rgso_trait_name = Ident::new(
-        &format!("EditRGSOWrapper{}", struct_name),
+        &format!("EditRGSOConcrete{}", struct_name),
         Span::call_site(),
     );
 
@@ -687,7 +687,7 @@ pub(crate) fn generate_operative_streams(
 
         impl RIntoSchema for #struct_name {
             type Schema = Schema;
-            fn into_schema(instantiable: RGSOWrapper<Self, Schema>) -> Schema {
+            fn into_schema(instantiable: RGSOConcrete<Self, Schema>) -> Schema {
                 Schema::#struct_name(instantiable.to_owned())
             }
         }
@@ -707,7 +707,7 @@ pub(crate) fn generate_operative_streams(
             // TODO: Placeholder ()s
             fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, ()> ;
         }
-        impl<FieldsTS, SlotsTS> #edit_rgso_trait_name<FieldsTS, SlotsTS> for RGSOWrapper<#struct_name, Schema> {
+        impl<FieldsTS, SlotsTS> #edit_rgso_trait_name<FieldsTS, SlotsTS> for RGSOConcrete<#struct_name, Schema> {
             // TODO: Placeholder ()s
             fn edit(&self, graph: impl Into<std::rc::Rc<RBaseGraphEnvironment<Schema>>>) -> MainBuilder<#struct_name, Schema, FieldsTS, ()> {
                 MainBuilder {
@@ -727,7 +727,7 @@ pub(crate) fn generate_operative_streams(
                 let mut field_hashmap = std::collections::HashMap::new();
                 #(field_hashmap.insert(#unfulfilled_field_ids, RwSignal::new(None));)*
                 let graph: std::rc::Rc<RBaseGraphEnvironment<Self::Schema>> = graph.into();
-                let wrapper_builder = RGSOWrapperBuilder::new(
+                let wrapper_builder = RGSOConcreteBuilder::new(
                             field_hashmap,
                             #active_slot_tokens,
                             &operative_ref,

--- a/generate_schema_reactive/src/generate_operative_streams.rs
+++ b/generate_schema_reactive/src/generate_operative_streams.rs
@@ -974,7 +974,7 @@ pub(crate) fn generate_operative_streams(
                 let graph: std::rc::Rc<RBaseGraphEnvironment<Self::Schema>> = graph.into();
                 SubgraphBuilder::<#struct_name, Schema>::new(
                         None,
-                            id,
+                        id,
                         graph,
                     )
             }

--- a/generate_schema_reactive/src/generate_trait_impl_streams.rs
+++ b/generate_schema_reactive/src/generate_trait_impl_streams.rs
@@ -53,7 +53,7 @@ pub(crate) fn generate_trait_impl_streams(
                 }
             });
             quote! {
-                impl #trait_name for RGSOWrapper<#instantiable_name, Schema> {
+                impl #trait_name for RGSOConcrete<#instantiable_name, Schema> {
                     #(#fn_streams)*
                 }
             }

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -517,11 +517,11 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         pub use leptos::*;
         use base_types::utils::*;
 
-        // Purpose of the MainBuilder is to hide internal details which are exposed on the RGSOBuilder
+        // Purpose of the MainBuilder is to hide internal details which are exposed on the SubgraphBuilder
         pub struct MainBuilder<T, TSchema, FieldsTS, SlotsTS>
             where TSchema: EditRGSO<Schema = TSchema> + 'static
         {
-            inner_builder: RGSOBuilder<T, TSchema>,
+            inner_builder: SubgraphBuilder<T, TSchema>,
             _fields_typestate: std::marker::PhantomData<FieldsTS>,
             _slots_typestate: std::marker::PhantomData<SlotsTS>,
         }
@@ -565,7 +565,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 graph: std::rc::Rc<RBaseGraphEnvironment<TSchema>>,
             ) -> Self {
                 Self {
-                    inner_builder: RGSOBuilder::new(builder_wrapper_instance, id, graph),
+                    inner_builder: SubgraphBuilder::new(builder_wrapper_instance, id, graph),
                     _slots_typestate: std::marker::PhantomData,
                     _fields_typestate: std::marker::PhantomData,
                 }
@@ -583,10 +583,10 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 instantiable: Option<MainBuilder<C, TSchema, FieldsTS, SlotsTS>>,
             ) {
                 let instantiable = instantiable.map(|builder| builder.inner_builder);
-                RGSOBuilder::add_outgoing(&mut self.inner_builder, slot_id, target_id, instantiable)
+                SubgraphBuilder::add_outgoing(&mut self.inner_builder, slot_id, target_id, instantiable)
             }
             fn remove_outgoing(&mut self, slot_ref: SlotRef) {
-                RGSOBuilder::remove_outgoing(&mut self.inner_builder, slot_ref)
+                SubgraphBuilder::remove_outgoing(&mut self.inner_builder, slot_ref)
             }
             fn add_incoming<C: std::fmt::Debug + Clone + RIntoSchema<Schema = TSchema> + 'static + Sized>(
                 &mut self,
@@ -594,10 +594,10 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 instantiable: Option<MainBuilder<C, TSchema, FieldsTS, SlotsTS>>,
             ) {
                 let instantiable = instantiable.map(|builder| builder.inner_builder);
-                RGSOBuilder::add_incoming(&mut self.inner_builder, slot_ref, instantiable)
+                SubgraphBuilder::add_incoming(&mut self.inner_builder, slot_ref, instantiable)
             }
             fn edit_field(&mut self, field_id: Uid, value: PrimitiveValues) {
-                RGSOBuilder::edit_field(&mut self.inner_builder, field_id, value)
+                SubgraphBuilder::edit_field(&mut self.inner_builder, field_id, value)
             }
             fn delete(&mut self, to_delete_id: &Uid) {
                 self.inner_builder.delete(to_delete_id)

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -2,6 +2,8 @@
 Code generation crate which ingests a schema and outputs static types to be included in a project.
 */
 
+pub use to_composite_id_macro;
+
 use base_types::common::Uid;
 use base_types::constraint_schema::*;
 use base_types::constraint_schema_item::ConstraintSchemaItem;

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -544,7 +544,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 self.inner_builder.incorporate(&other_builder.inner_builder)
             }
 
-            pub fn set_temp_id(&mut self, temp_id: &str) -> &mut Self {
+            pub fn set_temp_id(mut self, temp_id: &str) -> Self {
                 self.inner_builder.set_temp_id(temp_id);
                 self
             }

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -520,6 +520,12 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         use typenum::*;
         use base_types::utils::*;
 
+        pub trait StaticTypestate {
+            type InitialSlotTypestate;
+            type EmptyFieldTypestate;
+            type FulfilledFieldTypestate;
+        }
+
         pub struct ExistingBuilder<T: std::clone::Clone + std::fmt::Debug, TSchema>
         where TSchema: 'static
         {

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -515,6 +515,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         pub use base_types::post_generation::*;
         pub use base_types::primitives::*;
         pub use leptos::*;
+        use typenum::*;
         use base_types::utils::*;
 
         // Purpose of the MainBuilder is to hide internal details which are exposed on the SubgraphBuilder
@@ -536,9 +537,9 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
             pub fn execute(&self) -> Result<ExecutionResult, ElementCreationError> {
                 self.inner_builder.execute()
             }
-            pub fn incorporate<C: std::fmt::Debug + Clone + RIntoSchema<Schema = TSchema> + 'static>(
+            pub fn incorporate<C: std::fmt::Debug + Clone + RIntoSchema<Schema = TSchema> + 'static, OtherBuilderFieldsTS, OtherBuilderSlotsTS>(
                 &mut self,
-                other_builder: &MainBuilder<C, TSchema, FieldsTS, SlotsTS>,
+                other_builder: &MainBuilder<C, TSchema, OtherBuilderFieldsTS, OtherBuilderSlotsTS>,
             ) {
                 self.inner_builder.incorporate(&other_builder.inner_builder)
             }

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -643,7 +643,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         }
         #[derive(Debug, Clone)]
         pub enum NonReactiveSchema {
-            #(#all_lib_op_names(base_types::post_generation::GSOWrapper<#all_lib_op_names>),)*
+            #(#all_lib_op_names(base_types::post_generation::GSOConcrete<#all_lib_op_names>),)*
         }
         impl From<Schema> for NonReactiveSchema {
             fn from(value: Schema) -> Self {

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -527,7 +527,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         }
         impl <T, TSchema: EditRGSO<Schema = TSchema> + 'static, FieldsTS, SlotsTS> MainBuilder<T, TSchema, FieldsTS, SlotsTS>
             where
-                RGSOWrapperBuilder<T, TSchema>: RProducable<RGSOWrapper<T, TSchema>>,
+                RGSOConcreteBuilder<T, TSchema>: RProducable<RGSOConcrete<T, TSchema>>,
                 T: RIntoSchema<Schema = TSchema> + Clone + std::fmt::Debug + 'static,
             {
             pub fn get_id(&self) -> &Uid {
@@ -560,7 +560,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 self.inner_builder.get_graph()
             }
             fn new(
-                builder_wrapper_instance: Option<RGSOWrapperBuilder<T, TSchema>>,
+                builder_wrapper_instance: Option<RGSOConcreteBuilder<T, TSchema>>,
                 id: Uid,
                 graph: std::rc::Rc<RBaseGraphEnvironment<TSchema>>,
             ) -> Self {
@@ -639,7 +639,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
 
         #[derive(Debug, Clone)]
         pub enum Schema {
-            #(#all_lib_op_names(RGSOWrapper<#all_lib_op_names, Schema>),)*
+            #(#all_lib_op_names(RGSOConcrete<#all_lib_op_names, Schema>),)*
         }
         #[derive(Debug, Clone)]
         pub enum NonReactiveSchema {
@@ -674,14 +674,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
             use base_types::post_generation::*;
             use base_types::post_generation::reactive::*;
 
-            impl RFieldEditable for Schema {
-                fn apply_field_edit(&self, field_edit: base_types::post_generation::FieldEdit) {
-                    match self {
-                    #(Self::#all_lib_op_names(item) => item.apply_field_edit(field_edit),)*
-                    // _ => panic!(),
-                    }
-                }
-            }
             impl EditRGSO for Schema {
                 fn remove_outgoing(& self, slot_ref: &base_types::post_generation::SlotRef) -> & Self{
                     match self {
@@ -716,7 +708,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
             }
         }
 
-        impl From<Schema> for base_types::post_generation::StandaloneRGSOWrapper {
+        impl From<Schema> for base_types::post_generation::StandaloneRGSOConcrete {
            fn from(value: Schema) -> Self {
                let outgoing_slots = value.outgoing_slots().values().fold(Vec::new(), |mut agg, slot| {
                     let new_slot_refs = slot.slotted_instances.get().iter().map(|instance_id| {

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -82,7 +82,7 @@ fn impl_RGSO_for_enum(enum_name: TokenStream, members: Vec<syn::Ident>) -> Token
                     // _ => panic!(),
                 }
             }
-            fn outgoing_slots(&self) -> &std::collections::HashMap<base_types::common::Uid, RActiveSlot>{
+            fn outgoing_slots(&self) -> &std::collections::BTreeMap<base_types::common::Uid, RActiveSlot>{
                 match self {
                     #(Self::#members(item) => item.outgoing_slots(),)*
                     // _ => panic!(),
@@ -521,7 +521,7 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
         use base_types::utils::*;
 
         // Purpose of the MainBuilder is to hide internal details which are exposed on the SubgraphBuilder
-        pub struct MainBuilder<T, TSchema, FieldsTS, SlotsTS>
+        pub struct MainBuilder<T: std::clone::Clone + std::fmt::Debug, TSchema, FieldsTS, SlotsTS>
             where TSchema: EditRGSO<Schema = TSchema> + 'static
         {
             inner_builder: SubgraphBuilder<T, TSchema>,

--- a/generate_schema_reactive/src/lib.rs
+++ b/generate_schema_reactive/src/lib.rs
@@ -263,8 +263,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                     agg
                 },
             );
-            // let field_trait_fns_streams = field_trait_fns.values().map(|item| item.fn_signature.clone()).collect::<Vec<_>>();
-            // let field_trait_fns_names = field_trait_fns.values().map(|item| item.fn_name.clone()).collect::<Vec<_>>();
 
             let IntermediateSlotTraitInfo {
                 trait_name: slot_trait_name,
@@ -315,12 +313,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 },
             );
 
-            // let field_match_code = quote!{
-            //     match self {
-            //         #(#enum_name::#subclass_op_names(val) => val.#field_trait_fns_names(),)*
-            //         _ => panic!(),
-            //     }
-            // };
             let rgso_impl = impl_RGSO_for_enum(enum_name.clone(), subclass_op_names.clone());
             if subclass_op_names.len() <= 1 {
                 None
@@ -337,9 +329,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                          }
                      }
                     impl #field_trait_name for #enum_name {
-                        // #(#field_trait_fns_streams {
-                        //     #field_match_code
-                        // })*
                         #(#field_streams)*
                     }
                     impl #slot_trait_name for #enum_name {
@@ -597,73 +586,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
                 self.inner_builder.set_temp_id(temp_id);
                 self
             }
-
-        //     fn delete_recursive_handler(&self, id: &Uid) {
-        //         self.inner_builder.delete_recursive_handler(id)
-        //     }
-        //     fn get_blueprint(
-        //         mut self,
-        //     ) -> Result<(Blueprint<TSchema>, ExecutionResult), ElementCreationError> {
-        //         self.inner_builder.get_blueprint()
-        //     }
-        //     fn get_graph(&self) -> &std::rc::Rc<RBaseGraphEnvironment<TSchema>> {
-        //         self.inner_builder.get_graph()
-        //     }
-        //     fn new(
-        //         builder_wrapper_instance: Option<RGSOConcreteBuilder<T, TSchema>>,
-        //         id: Uid,
-        //         graph: std::rc::Rc<RBaseGraphEnvironment<TSchema>>,
-        //     ) -> Self {
-        //         Self {
-        //             inner_builder: SubgraphBuilder::new(builder_wrapper_instance, id, graph),
-        //             _slots_typestate: std::marker::PhantomData,
-        //             _fields_typestate: std::marker::PhantomData,
-        //         }
-        //     }
-        //     fn raw_add_outgoing_to_updates(&mut self, slot_ref: SlotRef) {
-        //         self.inner_builder.raw_add_outgoing_to_updates(slot_ref)
-        //     }
-        //     fn raw_add_incoming_to_updates(&mut self, slot_ref: SlotRef) {
-        //         self.inner_builder.raw_add_incoming_to_updates(slot_ref)
-        //     }
-        //     fn add_outgoing<C: std::fmt::Debug + Clone + RIntoSchema<Schema = TSchema> + 'static + Sized>(
-        //         &mut self,
-        //         slot_id: &Uid,
-        //         target_id: BlueprintId,
-        //         instantiable: Option<FreshBuilder<C, TSchema, FieldsTS, SlotsTS>>,
-        //     ) {
-        //         let instantiable = instantiable.map(|builder| builder.inner_builder);
-        //         SubgraphBuilder::add_outgoing(&mut self.inner_builder, slot_id, target_id, instantiable)
-        //     }
-        //     fn remove_outgoing(&mut self, slot_ref: SlotRef) {
-        //         SubgraphBuilder::remove_outgoing(&mut self.inner_builder, slot_ref)
-        //     }
-        //     fn add_incoming<C: std::fmt::Debug + Clone + RIntoSchema<Schema = TSchema> + 'static + Sized>(
-        //         &mut self,
-        //         slot_ref: SlotRef,
-        //         instantiable: Option<FreshBuilder<C, TSchema, FieldsTS, SlotsTS>>,
-        //     ) {
-        //         let instantiable = instantiable.map(|builder| builder.inner_builder);
-        //         SubgraphBuilder::add_incoming(&mut self.inner_builder, slot_ref, instantiable)
-        //     }
-        //     fn edit_field(&mut self, field_id: Uid, value: PrimitiveValues) {
-        //         SubgraphBuilder::edit_field(&mut self.inner_builder, field_id, value)
-        //     }
-        //     fn delete(&mut self, to_delete_id: &Uid) {
-        //         self.inner_builder.delete(to_delete_id)
-        //     }
-        //     fn delete_recursive(&mut self) {
-        //         self.inner_builder.delete_recursive()
-        //     }
-        //     fn temp_add_incoming(&mut self, host_id: BlueprintId, temp_slot_ref: TempAddIncomingSlotRef) {
-        //         self.inner_builder.temp_add_incoming(host_id, temp_slot_ref)
-        //     }
-        //     fn temp_add_outgoing(&mut self, target_id: BlueprintId, temp_slot_ref: TempAddOutgoingSlotRef) {
-        //         self.inner_builder.temp_add_outgoing(target_id, temp_slot_ref)
-        //     }
-        //     fn add_error(&mut self, error: ElementCreationError) {
-        //         self.inner_builder.add_error(error)
-        //     }
         }
 
         // #trait_file_stream
@@ -680,7 +602,6 @@ pub fn generate_concrete_schema_reactive(schema_location: &Path) -> String {
 
         lazy_static::lazy_static!{
             pub static ref CONSTRAINT_SCHEMA: base_types::constraint_schema::ConstraintSchema<PrimitiveTypes, PrimitiveValues>
-            // = constraint_schema::constraint_schema!();
             = serde_json::from_str::<base_types::constraint_schema::ConstraintSchema<PrimitiveTypes, PrimitiveValues>>(#raw_json_data).expect("Schema formatted incorrectly");
         }
 

--- a/generate_schema_reactive/src/utils.rs
+++ b/generate_schema_reactive/src/utils.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_operative_variant_name(operative_name: &str) -> syn::Ident {
 pub(crate) fn get_operative_wrapped_name(operative_name: &str) -> TokenStream {
     let op_name = get_operative_variant_name(operative_name);
 
-    quote! {RGSOWrapper<#op_name, Schema>}
+    quote! {RGSOConcrete<#op_name, Schema>}
 }
 
 pub(crate) fn get_template_get_field_fn_name(field_name: &str) -> syn::Ident {

--- a/molecule_core/Cargo.toml
+++ b/molecule_core/Cargo.toml
@@ -1,0 +1,10 @@
+
+
+[package]
+name = "molecule_core"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+typenum = "1"

--- a/molecule_core/src/lib.rs
+++ b/molecule_core/src/lib.rs
@@ -1,0 +1,29 @@
+use std::marker::PhantomData;
+
+use typenum::*;
+
+pub struct CompId<A, B, C, D>(PhantomData<(A, B, C, D)>);
+// impl<A: Unsigned, B: Unsigned, C: Unsigned, D: Unsigned> CompId for CompositeId<A, B, C, D> {}
+
+// Implement PartialEq for CompositeId
+impl<A, B, C, D> PartialEq for CompId<A, B, C, D> {
+    fn eq(&self, _other: &Self) -> bool {
+        // This is always true because if the types are the same, the values are the same
+        true
+    }
+}
+impl<A: Unsigned, B: Unsigned, C: Unsigned, D: Unsigned> CompId<A, B, C, D> {
+    pub fn new() -> Self {
+        CompId(PhantomData)
+    }
+}
+
+impl<A: Unsigned, B: Unsigned, C: Unsigned, D: Unsigned> IdToU32 for CompId<A, B, C, D> {
+    fn to_u32() -> u32 {
+        (A::to_u32() << 24) | (B::to_u32() << 16) | (C::to_u32() << 8) | D::to_u32()
+    }
+}
+
+pub trait IdToU32 {
+    fn to_u32() -> u32;
+}

--- a/readme.md
+++ b/readme.md
@@ -69,8 +69,8 @@ Use the graph toolkit to build and manipulate instances of your data.
 
   ```
   - This new sentence now exists in your graph environment, and you can access it using `graph.get(sentence_id).unwrap()`. The sentence can be used in UIs in a reactive way because all fields and slots are stored as reactive signals courtesy of Leptos's signal system. This means you can build a visualization of your data type in such a way that making changes to nested structure is automatically propagated to the UI.
-  - You interact with elements in your graph through a structure called the MainBuilder, which is returned from `{operative_name}::new()` or `{instance_of_operative}.edit()`. This structure will have the legal operations according to your schema (e.g. methods to add or remove elements to slots, or to set fields).
-  - Call `.execute()` on your MainBuilder to attempt to commit the transaction to the graph. If there are no errors, all contained graph operations will be commited, if it fails, none of the operations will occur.
+  - You interact with elements in your graph through a structure called the FreshBuilder, which is returned from `{operative_name}::new()` or `{instance_of_operative}.edit()`. This structure will have the legal operations according to your schema (e.g. methods to add or remove elements to slots, or to set fields).
+  - Call `.execute()` on your FreshBuilder to attempt to commit the transaction to the graph. If there are no errors, all contained graph operations will be commited, if it fails, none of the operations will occur.
   - The toolkit will error if created elements don't fulfill all of their constraints, or if newly added slotted instances break the schema constraints.
   - Call `graph.undo()` and `graph.redo()` to manipulate your historical transactions.
 ### (Optional) Connect to Neo4j for visualization.

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ Use the graph toolkit to build and manipulate instances of your data.
   ```
   - This new sentence now exists in your graph environment, and you can access it using `graph.get(sentence_id).unwrap()`. The sentence can be used in UIs in a reactive way because all fields and slots are stored as reactive signals courtesy of Leptos's signal system. This means you can build a visualization of your data type in such a way that making changes to nested structure is automatically propagated to the UI.
   - You interact with elements in your graph through a structure called the MainBuilder, which is returned from `{operative_name}::new()` or `{instance_of_operative}.edit()`. This structure will have the legal operations according to your schema (e.g. methods to add or remove elements to slots, or to set fields).
-  - Call `.execute()` on your RGSOBuilder to attempt to commit the transaction to the graph. If there are no errors, all contained graph operations will be commited, if it fails, none of the operations will occur.
+  - Call `.execute()` on your MainBuilder to attempt to commit the transaction to the graph. If there are no errors, all contained graph operations will be commited, if it fails, none of the operations will occur.
   - The toolkit will error if created elements don't fulfill all of their constraints, or if newly added slotted instances break the schema constraints.
   - Call `graph.undo()` and `graph.redo()` to manipulate your historical transactions.
 ### (Optional) Connect to Neo4j for visualization.

--- a/resources/neo4j_creation_example.rs
+++ b/resources/neo4j_creation_example.rs
@@ -3,7 +3,7 @@ use base_types::{common::u128_to_string, primitives::PrimitiveValues };
 use neo4rs::*;
 use crate::app::prelude::CONSTRAINT_SCHEMA;
 
-pub async fn save_graph(Json(payload): Json<Vec<base_types::post_generation::StandaloneRGSOWrapper>>) -> (StatusCode, ()) {
+pub async fn save_graph(Json(payload): Json<Vec<base_types::post_generation::StandaloneRGSOConcrete>>) -> (StatusCode, ()) {
     let uri = "neo4j://localhost:7687";
 
     let pass = "********";

--- a/to_composite_id_macro/Cargo.toml
+++ b/to_composite_id_macro/Cargo.toml
@@ -1,0 +1,15 @@
+
+[package]
+name = "to_composite_id_macro"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+typenum = "1"
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1"
+molecule_core = { path = "../molecule_core" }
+
+[lib]
+proc-macro = true

--- a/to_composite_id_macro/src/lib.rs
+++ b/to_composite_id_macro/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{parse_macro_input, LitInt};
+
+#[proc_macro]
+pub fn to_comp_id(input: TokenStream) -> TokenStream {
+    let value = parse_macro_input!(input as LitInt)
+        .base10_parse::<u32>()
+        .unwrap();
+
+    let a = (value >> 24) & 0xFF;
+    let b = (value >> 16) & 0xFF;
+    let c = (value >> 8) & 0xFF;
+    let d = value & 0xFF;
+
+    let a_type = quote::format_ident!("U{}", a, span = Span::call_site());
+    let b_type = quote::format_ident!("U{}", b, span = Span::call_site());
+    let c_type = quote::format_ident!("U{}", c, span = Span::call_site());
+    let d_type = quote::format_ident!("U{}", d, span = Span::call_site());
+
+    let expanded = quote! {
+        molecule_core::CompId<typenum::#a_type, typenum::#b_type, typenum::#c_type, typenum::#d_type>
+    };
+
+    expanded.into()
+}


### PR DESCRIPTION
Adds typestate to new operative builders. This keeps any graph operation which is creating new operatives entirely compile-time safe. Unfortunately there can still be runtime errors when making edits to existing constructs within the graph.